### PR TITLE
Update ckeditor.js

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -1,88 +1,87 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-export default class CKEditor extends React.Component {
+class CKEditor extends React.Component {
+  constructor(props) {
+    super(props);
 
-	constructor( props ) {
-		super( props );
+    this.editorInstance = null;
+  }
 
-		this.editorInstance = null;
-	}
+  // Update editor data if data property is changed.
+  UNSAFE_componentWillReceiveProps(newProps) {
+    if (this.editorInstance && newProps.data) {
+      this.editorInstance.setData(newProps.data);
+    }
+  }
 
-	// This component should never be updated by React itself.
-	shouldComponentUpdate() {
-		return false;
-	}
+  // Initialize editor when component is mounted.
+  componentDidMount() {
+    this._initializeEditor();
+  }
 
-	// Update editor data if data property is changed.
-	componentWillReceiveProps( newProps ) {
-		if ( this.editorInstance && newProps.data ) {
-			this.editorInstance.setData( newProps.data );
-		}
-	}
+  // This component should never be updated by React itself.
+  shouldComponentUpdate() {
+    return false;
+  }
 
-	// Initialize editor when component is mounted.
-	componentDidMount() {
-		this._initializeEditor();
-	}
+  // Destroy editor before unmouting component.
+  componentWillUnmount() {
+    this._destroyEditor();
+  }
 
-	// Destroy editor before unmouting component.
-	componentWillUnmount() {
-		this._destroyEditor();
-	}
+  _destroyEditor() {
+    if (this.editorInstance) {
+      this.editorInstance.destroy();
+    }
+  }
 
-	// Render <div> element which will be replaced by CKEditor.
-	render() {
-		return <div ref={ ref => ( this.domContainer = ref ) }></div>;
-	}
+  _initializeEditor() {
+    const { editor, config, data, onInit, onChange } = this.props;
+    editor
+      .create(this.domContainer, config)
+      .then(editor => {
+        this.editorInstance = editor;
 
-	_initializeEditor() {
-		this.props.editor
-			.create( this.domContainer, this.props.config )
-			.then( editor => {
-				this.editorInstance = editor;
+        // TODO: Pass data via constructor.
+        this.editorInstance.setData(data);
 
-				// TODO: Pass data via constructor.
-				this.editorInstance.setData( this.props.data );
+        // TODO: Add example using it.
+        if (onInit) onInit(editor);
 
-				// TODO: Add example using it.
-				if ( this.props.onInit ) {
-					this.props.onInit( editor );
-				}
+        if (onChange) {
+          const document = this.editorInstance.model.document;
+          document.on("change", () => {
+            if (document.differ.getChanges().length > 0) {
+              onChange(editor.getData());
+            }
+          });
+        }
+      })
+      .catch(error => {
+        console.error(error);
+      });
+  }
 
-				if ( this.props.onChange ) {
-					const document = this.editorInstance.model.document;
-					document.on( 'change', () => {
-						if ( document.differ.getChanges().length > 0 ) {
-							this.props.onChange( editor.getData() );
-						}
-					} );
-				}
-			} )
-			.catch( error => {
-				console.error( error );
-			} );
-	}
-
-	_destroyEditor() {
-		if ( this.editorInstance ) {
-			this.editorInstance.destroy();
-		}
-	}
+  // Render <div> element which will be replaced by CKEditor.
+  render() {
+    return <div ref={ref => (this.domContainer = ref)} />;
+  }
 }
 
 // Properties definition.
 CKEditor.propTypes = {
-	editor: PropTypes.func.isRequired,
-	data: PropTypes.string,
-	config: PropTypes.object,
-	onChange: PropTypes.func,
-	onInit: PropTypes.func
+  config: PropTypes.object,
+  data: PropTypes.string,
+  editor: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
+  onInit: PropTypes.func
 };
 
 // Default values for non-required properties.
 CKEditor.defaultProps = {
-	data: '',
-	config: {}
+  config: {},
+  data: ""
 };
 
+export default CKEditor;


### PR DESCRIPTION
Because of https://github.com/ckeditor/ckeditor5-react/issues/7 I copied all the code from `ckeditor.js` in my project (in a new component file).

I'm using `create-react-app` and eslint. So the errors:

- [eslint] componentWillReceiveProps is deprecated since React 16.3.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops (react/no-deprecated)

- [eslint] shouldComponentUpdate should be placed after UNSAFE_componentWillReceiveProps (react/sort-comp)

- [eslint] shouldComponentUpdate should be placed after componentDidMount (react/sort-comp)

- [eslint] render should be placed after _destroyEditor (react/sort-comp)

- [eslint] Default prop types declarations should be sorted alphabetically (react/jsx-sort-default-props)

- [eslint] Must use destructuring props assignment (react/destructuring-assignment)

**What is still a problem** (and I don't know how to fix):

- [eslint] UNSAFE_componentWillReceiveProps is unsafe for use in async rendering, see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html (react/no-unsafe)

- Unexpected console statement. (no-console) (62, 9)

- JSX props should not use arrow functions (react/jsx-no-bind) (68, 17)

- Prop type `object` is forbidden (react/forbid-prop-types) (74, 3)

- propType "onChange" is not required, but has no corresponding defaultProp declaration. (react/require-default-props) (77, 3)

- propType "onInit" is not required, but has no corresponding defaultProp declaration. (react/require-default-props) (78, 3)