### PR TITLE
Replaced running Karma from CLI to a custom script

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "changelog": "node ./scripts/changelog.js",
     "prerelease": "npm run build; if [ -n \"$(git status dist/ --porcelain)\" ]; then git add -u dist/ && git commit -m 'Internal: Build.'; fi",
     "release": "node ./scripts/release.js",
-    "test": "karma start",
-    "coverage": "karma start --coverage"
+    "test": "node ./scripts/test.js",
+    "coverage": "node ./scripts/test.js --coverage"
   },
   "repository": {
     "type": "git",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* eslint-env node */
+
+// This scripts run the Karma's server and tests. It does the same job what `karma start` but
+// we need to do it manually because options passed by CLI can overwrite the karma configuration
+// which produces invalid config.
+// See: https://github.com/ckeditor/ckeditor5-react/issues/25
+
+const getKarmaConfig = require( './utils/getkarmaconfig' );
+const { Server: KarmaServer } = require( 'karma' );
+
+const config = getKarmaConfig();
+
+const server = new KarmaServer( config );
+
+server.start();

--- a/scripts/utils/getkarmaconfig.js
+++ b/scripts/utils/getkarmaconfig.js
@@ -11,7 +11,7 @@ const path = require( 'path' );
 
 const options = parseArguments( process.argv.slice( 2 ) );
 
-module.exports = function getKarmaConfig( config ) {
+module.exports = function getKarmaConfig() {
 	const basePath = process.cwd();
 	const coverageDir = path.join( basePath, 'coverage' );
 
@@ -157,7 +157,7 @@ module.exports = function getKarmaConfig( config ) {
 		webpackConfig.devtool = 'inline-source-map';
 	}
 
-	config.set( karmaConfig );
+	return karmaConfig;
 };
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Test environment will be created from a custom script instead of using Karma's CLI. Closes #25.

---

### Additional information

Karma must be called manually because options specified in CLI overwrites its config.
