### PR TITLE
Revert "Merge pull request #73 from ckeditor/t/72"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "ckeditor 5"
   ],
   "dependencies": {
-    "lodash-es": "^4.17.11",
     "prop-types": "^15.6.1"
   },
   "devDependencies": {

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { cloneDeepWith, isPlainObject, isElement } from 'lodash-es';
 
 export default class CKEditor extends React.Component {
 	constructor( props ) {
@@ -52,7 +51,7 @@ export default class CKEditor extends React.Component {
 
 	_initializeEditor() {
 		this.props.editor
-			.create( this.domContainer.current , parseConfig( this.props.config ) )
+			.create( this.domContainer.current , this.props.config )
 			.then( editor => {
 				this.editor = editor;
 
@@ -137,11 +136,3 @@ CKEditor.defaultProps = {
 	config: {}
 };
 
-function parseConfig( config ) {
-	// Replaces all DOM references created using React.createRef() with the "current" DOM node.
-	return cloneDeepWith( config, value => {
-		if ( isPlainObject( value ) && isElement( value.current ) && Object.keys( value ).length === 1 ) {
-			return value.current;
-		}
-	} );
-}

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -123,43 +123,6 @@ describe( 'CKEditor Component', () => {
 	} );
 
 	describe( 'properties', () => {
-		it( 'sets editor\'s data if properties have changed and contain the "data" key', done => {
-			const editorInstance = new Editor();
-
-			sandbox.stub( Editor, 'create' ).resolves( editorInstance );
-			sandbox.stub( editorInstance, 'setData' );
-			sandbox.stub( editorInstance, 'getData' ).returns( '<p>&nbsp;</p>' );
-
-			wrapper = mount( <CKEditor editor={ Editor } /> );
-
-			setTimeout( () => {
-				wrapper.setProps( { data: '<p>Foo Bar.</p>' });
-
-				expect( editorInstance.setData.calledOnce ).to.be.true;
-				expect( editorInstance.setData.firstCall.args[ 0 ] ).to.equal( '<p>Foo Bar.</p>' );
-
-				done();
-			} );
-		} );
-
-		it( 'does not update the editor\'s data if value under "data" key is equal to editor\'s data', done => {
-			const editorInstance = new Editor();
-
-			sandbox.stub( Editor, 'create' ).resolves( editorInstance );
-			sandbox.stub( editorInstance, 'setData' );
-			sandbox.stub( editorInstance, 'getData' ).returns( '<p>Foo Bar.</p>' );
-
-			wrapper = mount( <CKEditor editor={ Editor } /> );
-
-			setTimeout( () => {
-				wrapper.setProps( { data: '<p>Foo Bar.</p>' });
-
-				expect( editorInstance.setData.calledOnce ).to.be.false;
-
-				done();
-			} );
-		} );
-
 		describe( '#onInit', () => {
 			it( 'calls "onInit" callback if specified when the editor is ready to use', done => {
 				const editorInstance = new Editor();

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -123,63 +123,40 @@ describe( 'CKEditor Component', () => {
 	} );
 
 	describe( 'properties', () => {
-		describe( '#config', () => {
-			it( 'should replace all react DOM references with the `current` DOM element', done => {
-				const spy = sinon.spy( Editor, 'create' );
+		it( 'sets editor\'s data if properties have changed and contain the "data" key', done => {
+			const editorInstance = new Editor();
 
-				const domElement = document.createElement( 'div' );
-				const domElementRef = React.createRef();
-				const similarToDomElementRef = {
-					current: domElement,
-					foo: 'bar'
-				};
+			sandbox.stub( Editor, 'create' ).resolves( editorInstance );
+			sandbox.stub( editorInstance, 'setData' );
+			sandbox.stub( editorInstance, 'getData' ).returns( '<p>&nbsp;</p>' );
 
-				const config = {
-					domElement,
-					domElementRef,
-					nested: {
-						domElementRef
-					},
-					similarToDomElementRef,
-					array: [
-						domElementRef, domElement, similarToDomElementRef
-					]
-				};
+			wrapper = mount( <CKEditor editor={ Editor } /> );
 
-				wrapper = mount(
-					<div>
-						<div ref={ domElementRef }></div>
-						<CKEditor editor={ Editor } config={ config } />
-					</div>
-				);
+			setTimeout( () => {
+				wrapper.setProps( { data: '<p>Foo Bar.</p>' });
 
-				setTimeout( () => {
-					const parsedConfig = spy.lastCall.args[ 1 ];
+				expect( editorInstance.setData.calledOnce ).to.be.true;
+				expect( editorInstance.setData.firstCall.args[ 0 ] ).to.equal( '<p>Foo Bar.</p>' );
 
-					// Not changed.
-					expect( parsedConfig.domElement ).to.equal( domElement ).to.instanceof( HTMLElement );
+				done();
+			} );
+		} );
 
-					// Changed.
-					expect( parsedConfig.domElementRef ).to.equal( domElementRef.current ).to.instanceof( HTMLElement );
+		it( 'does not update the editor\'s data if value under "data" key is equal to editor\'s data', done => {
+			const editorInstance = new Editor();
 
-					// Changed.
-					expect( parsedConfig.nested.domElementRef ).to.equal( domElementRef.current ).to.instanceof( HTMLElement );
+			sandbox.stub( Editor, 'create' ).resolves( editorInstance );
+			sandbox.stub( editorInstance, 'setData' );
+			sandbox.stub( editorInstance, 'getData' ).returns( '<p>Foo Bar.</p>' );
 
-					// Not changed.
-					expect( parsedConfig.similarToDomElementRef ).to.deep.equal( similarToDomElementRef );
-					expect( parsedConfig.similarToDomElementRef.current ).to.equal( domElement );
+			wrapper = mount( <CKEditor editor={ Editor } /> );
 
-					// Changed.
-					expect( parsedConfig.array[ 0 ] ).to.equal( domElementRef.current ).to.instanceof( HTMLElement );
+			setTimeout( () => {
+				wrapper.setProps( { data: '<p>Foo Bar.</p>' });
 
-					// Not changed.
-					expect( parsedConfig.array[ 1 ] ).to.equal( domElement );
-					expect( parsedConfig.array[ 2 ] ).to.deep.equal( similarToDomElementRef );
-					expect( parsedConfig.array[ 2 ].current ).to.equal( domElement );
+				expect( editorInstance.setData.calledOnce ).to.be.false;
 
-					spy.restore();
-					done();
-				} );
+				done();
 			} );
 		} );
 


### PR DESCRIPTION
This reverts commit a31de76118130eae1ac8ae82c5c02917f996e211, reversing
changes made to 650b9ca41530491809bde7d29c6bfcd13ae68e55.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed option for providing React refs to the editor configuration. Closes https://github.com/ckeditor/ckeditor5-react/issues/72.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
