### PR TITLE
Component will not update anything if it is not ready

### DIFF
--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -18,6 +18,10 @@ export default class CKEditor extends React.Component {
 
 	// This component should never be updated by React itself.
 	shouldComponentUpdate( nextProps ) {
+		if ( !this.editor ) {
+			return false;
+		}
+
 		if ( this._shouldUpdateContent( nextProps ) ) {
 			this.editor.setData( nextProps.data );
 		}

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -123,6 +123,24 @@ describe( 'CKEditor Component', () => {
 	} );
 
 	describe( 'properties', () => {
+		// See: #83.
+		it( 'does not update anything if component is not ready', () => {
+			const editorInstance = new Editor();
+
+			sandbox.stub( Editor, 'create' ).resolves( editorInstance );
+
+			wrapper = mount( <CKEditor editor={ Editor } /> );
+
+			const component = wrapper.instance();
+			let shouldComponentUpdate;
+
+			expect( () => {
+				shouldComponentUpdate = component.shouldComponentUpdate( { disabled: true } );
+			} ).to.not.throw();
+
+			expect( shouldComponentUpdate ).to.be.false;
+		} );
+
 		describe( '#onInit', () => {
 			it( 'calls "onInit" callback if specified when the editor is ready to use', done => {
 				const editorInstance = new Editor();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `<CKEditor>` component will not update anything if it is not ready. Closes #83.
