### PR TITLE
React Component will be distributed as ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@ckeditor/ckeditor5-build-classic": "^12.0.0",
     "@ckeditor/ckeditor5-dev-env": "^15.0.0",

--- a/scripts/utils/getkarmaconfig.js
+++ b/scripts/utils/getkarmaconfig.js
@@ -25,7 +25,7 @@ module.exports = function getKarmaConfig() {
 					loader: 'babel-loader',
 					query: {
 						compact: false,
-						presets: [ '@babel/preset-react', '@babel/preset-env' ]
+						presets: [ '@babel/preset-react' ]
 					}
 				}
 			]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,7 @@ module.exports = {
 				exclude: /node_modules/,
 				query: {
 					compact: false,
-					presets: [ '@babel/preset-react', '@babel/preset-env' ]
+					presets: [ '@babel/preset-react' ]
 				}
 			}
 		]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `<CKEditor>` React component will be distributed in ES6 instead of ES5. Closes #105.

---

### Additional information

Two things:

- I am not sure how to define the merge message.
- Should it be marked as BC?

cc: @Reinmar 
