### PR TITLE
Add optional onError callback

### DIFF
--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -92,7 +92,12 @@ export default class CKEditor extends React.Component {
 				} );
 			} )
 			.catch( error => {
-				console.error( error );
+				if (this.props.onError) {
+					this.props.onError( error )
+				}
+				else {
+					console.error( error );
+				}
 			} );
 	}
 
@@ -132,6 +137,7 @@ CKEditor.propTypes = {
 	onInit: PropTypes.func,
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
+	onError: PropTypes.func,
 	disabled: PropTypes.bool
 };
 

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -92,12 +92,9 @@ export default class CKEditor extends React.Component {
 				} );
 			} )
 			.catch( error => {
-				if (this.props.onError) {
-					this.props.onError( error )
-				}
-				else {
-					console.error( error );
-				}
+				const onErrorCallback = this.props.onError || console.error;
+
+				onErrorCallback( error );
 			} );
 	}
 

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -102,7 +102,7 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
-		it( 'displays an error if something went wrong', done => {
+		it( 'displays an error if something went wrong and "onError" callback was not specified', done => {
 			const error = new Error( 'Something went wrong.' );
 			const consoleErrorStub = sandbox.stub( console, 'error' );
 
@@ -366,23 +366,22 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
-		describe('#onError', () => {
-			it( 'calls optional onError callback when error occurs', done => {
-				const ERROR_TEXT = 'Error was thrown.'
-				const errorHandler = sandbox.spy()
-	
-				sandbox.stub( Editor, 'create' ).rejects( ERROR_TEXT );
-				wrapper = mount( <CKEditor editor={ Editor } onError={ errorHandler } /> );
+		describe( '#onError', () => {
+			it( 'calls the callback if specified when an error occurs', done => {
+				const error = new Error( 'Error was thrown.' );
+				const errorHandler = sandbox.spy();
+
+				sandbox.stub( Editor, 'create' ).rejects( error );
+				wrapper = mount( <CKEditor editor={Editor} onError={errorHandler}/> );
 
 				setTimeout( () => {
 					expect( errorHandler.calledOnce ).to.equal( true );
 
-					// sinon stub.rejects puts the error text in the name, not message
-					expect( errorHandler.firstCall.args[ 0 ].name ).to.equal( ERROR_TEXT );
+					expect( errorHandler.firstCall.args[ 0 ] ).to.equal( error );
 					done();
 				} );
 			} );
-		}) 
+		} );
 
 		describe( '#disabled', () => {
 			it( 'switches the editor to read-only mode if [disabled={true}]', done => {

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -366,6 +366,24 @@ describe( 'CKEditor Component', () => {
 			} );
 		} );
 
+		describe('#onError', () => {
+			it( 'calls optional onError callback when error occurs', done => {
+				const ERROR_TEXT = 'Error was thrown.'
+				const errorHandler = sandbox.spy()
+	
+				sandbox.stub( Editor, 'create' ).rejects( ERROR_TEXT );
+				wrapper = mount( <CKEditor editor={ Editor } onError={ errorHandler } /> );
+
+				setTimeout( () => {
+					expect( errorHandler.calledOnce ).to.equal( true );
+
+					// sinon stub.rejects puts the error text in the name, not message
+					expect( errorHandler.firstCall.args[ 0 ].name ).to.equal( ERROR_TEXT );
+					done();
+				} );
+			} );
+		}) 
+
 		describe( '#disabled', () => {
 			it( 'switches the editor to read-only mode if [disabled={true}]', done => {
 				const onInit = function( editor ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced support for `onError` callback that is being called if an error occurred during the editor's initialization. Closes #123.

---

### Additional information

Because CKEditor5 does not expose an onError listener in events, for right now all we can expose is a callback for errors thrown when CKEditor5 is initialized in the CKEditor5-React component.
