### PR TITLE
Support for config.initialData when creating the component

### DIFF
--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -45,17 +45,14 @@ export default class CKEditor extends React.Component {
 
 	// Render a <div> element which will be replaced by CKEditor.
 	render() {
-		// We need to inject initial data to the container where the editable will be enabled. Using `editor.setData()`
-		// is a bad practice because it initializes the data after every new connection (in case of collaboration usage).
-		// It leads to reset the entire content. See: #68
 		return (
-			<div ref={ this.domContainer } dangerouslySetInnerHTML={ { __html: this.props.data || '' } }></div>
+			<div ref={ this.domContainer }></div>
 		);
 	}
 
 	_initializeEditor() {
 		this.props.editor
-			.create( this.domContainer.current, this.props.config )
+			.create( this.domContainer.current, this._getConfig() )
 			.then( editor => {
 				this.editor = editor;
 
@@ -122,6 +119,21 @@ export default class CKEditor extends React.Component {
 		}
 
 		return true;
+	}
+
+	_getConfig() {
+		if ( this.props.data && this.props.config.initialData ) {
+			console.warn(
+				'Editor data should be provided either using `config.initialData` or `data` properties. ' +
+				'The config property is over the data value and the first one will be used when specified both.'
+			);
+		}
+
+		// Merge two possible ways of providing data into the `config.initialData` field.
+		return {
+			...this.props.config,
+			initialData: this.props.config.initialData || this.props.data || ''
+		};
 	}
 }
 

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -110,6 +110,7 @@ describe( 'CKEditor Component', () => {
 			} } /> );
 
 			setTimeout( () => {
+				// We must restore "console.warn" before assertions in order to see warnings if they were logged.
 				consoleWarnStub.restore();
 
 				expect( consoleWarnStub.calledOnce ).to.be.true;
@@ -131,6 +132,7 @@ describe( 'CKEditor Component', () => {
 			} } /> );
 
 			setTimeout( () => {
+				// We must restore "console.warn" before assertions in order to see warnings if they were logged.
 				consoleWarnStub.restore();
 
 				expect( Editor.create.firstCall.args[ 1 ].initialData ).to.equal(


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Support for [`config.initialData`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorconfig-EditorConfig.html#member-initialData) in the configuration object when creating the component. When passing the `[data]` property and the `initialData` value in the configuration, the later one will take precedence and a warning message will be logged on the console.
