### PR TITLE
Fix: Add React 17 as a valid peerdependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "webpack-cli": "^3.3.12"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.13.1 | ^17.0.0"
   },
   "engines": {
     "node": ">=8.0.0",


### PR DESCRIPTION
Listing only React 16 creates a problem with React 17.

`npm ls react` reports that both React versions are missing.

