### PR TITLE
Use async/await in CKEditorContext#_destroyContext() to fix the destruction process

### DIFF
--- a/src/ckeditorcontext.jsx
+++ b/src/ckeditorcontext.jsx
@@ -79,9 +79,9 @@ export default class CKEditorContext extends React.Component {
 		} );
 	}
 
-	_destroyContext() {
+	async _destroyContext() {
 		if ( this.contextWatchdog ) {
-			this.contextWatchdog.destroy();
+			await this.contextWatchdog.destroy();
 			this.contextWatchdog = null;
 		}
 	}

--- a/tests/ckeditorcontext.jsx
+++ b/tests/ckeditorcontext.jsx
@@ -119,6 +119,36 @@ describe( '<CKEditorContext> Component', () => {
 			expect( editorCreateSpy.firstCall.args[ 1 ].initialData ).to.equal( '<p>Foo</p>' );
 			expect( editorCreateSpy.secondCall.args[ 1 ].initialData ).to.equal( '<p>Bar</p>' );
 		} );
+
+		it( 'should wait for the `ContextWatchdog#destroy()` promise when destroying the context feature', async () => {
+			let watchdog;
+
+			await new Promise( ( res, rej ) => {
+				wrapper = mount(
+					<CKEditorContext context={ ContextMock } onError={ rej }>
+					</CKEditorContext>
+				);
+
+				watchdog = wrapper.instance().contextWatchdog;
+
+				watchdog.on( 'stateChange', () => {
+					if ( watchdog.state === 'ready' ) {
+						res();
+					}
+				} );
+			} );
+
+			wrapper.unmount();
+			wrapper = null;
+
+			return new Promise( resolve => {
+				setTimeout( () => {
+					expect( watchdog._context ).to.equal( null );
+
+					resolve();
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'properties', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Use async/await in CKEditorContext#_destroyContext() to handle context destruction properly. Closes #283.

---

It is not that easy to test, so here is a short guide explaining how to do it:

1. Get the `real-time-collaboration-comments-outside-of-editor-for-react` collaboration sample and replace original `src/sample.js` with [my code](https://gist.github.com/Mgsy/9453453fd8b95ab97bf5ff8ab94d2857).
2. In `src/sample.js` add import path to the local `ckeditor5-react` package.
3. Build and run the sample.
4. Open the dev tools and the network tab.
5. Click the button to create editors.
6. The WebSocket connection should be _pending_.
7. Click the button to destroy editors.
8. The WebSocket connection should be closed.

The better description and GIFs are available in the original issue.
