### PR TITLE
Allowed the "license-header" ESLint rule. Fixed broken license headers across the project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* eslint-env node */
@@ -28,7 +28,13 @@ module.exports = {
 	'rules': {
 		'react/prop-types': 'off',
 		'no-console': 'off',
-		'no-trailing-spaces': 'error'
+		'no-trailing-spaces': 'error',
+		'ckeditor5-rules/license-header': [ 'error', { headerLines: [
+			'/**',
+			' * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.',
+			' * For licensing, see LICENSE.md.',
+			' */'
+		] } ]
 	},
 	'settings': {
 		'react': {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^7.5.0",
-    "eslint-config-ckeditor5": "^3.0.0",
+    "eslint-config-ckeditor5": "^4.0.0",
     "eslint-plugin-react": "^7.20.4",
     "husky": "^4.2.5",
     "istanbul-instrumenter-loader": "^3.0.1",
@@ -65,7 +65,7 @@
     "npm": ">=5.7.1"
   },
   "scripts": {
-    "lint": "eslint --quiet '**/*.js' '**/*.jsx'",
+    "lint": "eslint --quiet \"**/*.js\" \"**/*.jsx\"",
     "build": "webpack --mode production",
     "develop": "webpack --mode development --watch",
     "changelog": "node ./scripts/changelog.js",

--- a/tests/_utils/turnoffdefaulterrorcatching.js
+++ b/tests/_utils/turnoffdefaulterrorcatching.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* global window */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3078,18 +3078,18 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-ckeditor5@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-3.1.1.tgz#aeb289e858c7103aac09c9bd9347a60db62eedbc"
-  integrity sha512-fiV+pokuTd8wi9primorw06/XpXfhj7+LopRvuEdzqDumXpP0FUznllrnodogXE4+Mg9qX7tAs6YJeyArqyqQQ==
+eslint-config-ckeditor5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-4.0.0.tgz#6a4fc760525a0405532c4d6b095d8a17af3cba58"
+  integrity sha512-PDjWbo/PQ/gEvTGmNnEbLl63H+h0weQQkWV23jVCjvrr2Y5FyrVvQhizF5OqCDb5alSk1+RREUURZGhzMzy8LA==
   dependencies:
-    eslint-plugin-ckeditor5-rules "^1.0.0"
+    eslint-plugin-ckeditor5-rules "^4.0.0"
     eslint-plugin-mocha "^7.0.0"
 
-eslint-plugin-ckeditor5-rules@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-1.3.0.tgz#faf1fde859cf79e989f248e8a08e6955c317fdcd"
-  integrity sha512-7TjodWU2BRxbsCrhagRCn+V2Qh1UGmBnldG/jWL6HJgTPrsDYhqiS86aJUYsLR2FLEW6X39czXfI556qeMkCKQ==
+eslint-plugin-ckeditor5-rules@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-4.0.0.tgz#79d1fd8235212fe5b534b404ecba9a0f35aa1f92"
+  integrity sha512-zjePsfFahvkytgyWZtWOwaWyhXMUalTTQwXQ4XbX0x000R/4YmZh64ikCSJuW8v6acfvQcbFtCdXn/8+dipYKg==
 
 eslint-plugin-mocha@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
Internal: Allowed the "license-header" ESLint rule. Fixed broken license headers across the project. See https://github.com/ckeditor/ckeditor5/issues/11468.