### PR TITLE
Enforce cleanup completion before subsequent editor initialization

### DIFF
--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -148,10 +148,6 @@ export default class CKEditor extends React.Component {
 			await this.editorDestructionInProgress;
 		}
 
-		if ( this.watchdog ) {
-			return;
-		}
-
 		if ( this.context instanceof ContextWatchdog ) {
 			this.watchdog = new EditorWatchdogAdapter( this.context );
 		} else {


### PR DESCRIPTION
Fix: Fixed editor initialization running before a subsequently initiated destroy was completed. Closes #338.

---

### Additional information

These problems may have only become possible after the introduction of asynchronous behavior in #310 . In testing, it was evident that sometimes initializations of the editor were happening before cleanup from the unmounting phase completed, this is made possible by an asynchronous context. When that would occur, the initialization would detect an already present watchdog instance, and abort creating anew watchdog and paired editor instance. Subsequently the interrupted cleanup would continue and destroy the existing editor, leaving an empty div where the editor should be on the DOM. I haven't been able to replicate this issue using the `sample/index-18.html` file, so its probably only evident in larger applications.

A roadblock I encountered after running the tests was that there seemed to be occasions where the watchdog's destruction didn't return a promise, I wasn't expecting that, but I remedied it by checking it was a promise before calling `.then` on it.

I was able to remove a check for the watchdog existing that was added in #310, because waiting for pending destructions means that check is always passed.
