### PR TITLE
Fixed the component initialization procedure to enforce cleanup completion before subsequent editor initialization

### DIFF
--- a/sample/index-18-delayed.html
+++ b/sample/index-18-delayed.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<title>CKEditor 5 – React Component – development sample</title>
+	<style>
+		body {
+			max-width: 800px;
+			margin: 20px auto;
+		}
+
+		.button_read-only {
+			margin: 10px 0;
+		}
+
+	</style>
+</head>
+
+<body>
+	<h1>CKEditor 5 – React@18 Component – development sample</h1>
+	<p style="text-align: center;">Component's events are logged to the console. <b>React.StrictMode</b> is enabled.</p>
+	<button id="readOnly" class="button_read-only" disabled>Switch to read-only mode</button>
+	<button id="simulateError" class="button_read-only" disabled>Simulate an error</button>
+	<button id="previousDocumentID" class="button_read-only" disabled>Previous document id</button>
+	<button id="nextDocumentID" class="button_read-only">Next document id</button>
+	<div id="root"></div>
+	<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+	<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+	<script src="https://cdn.ckeditor.com/ckeditor5/34.0.0/classic/ckeditor.js"></script>
+	<script src="../dist/ckeditor.js"></script>
+	<script>
+		// TODO: Move buttons to the App component.
+		const nextDocumentIDButton = document.getElementById( 'nextDocumentID' );
+		const previousDocumentIDButton = document.getElementById( 'previousDocumentID' );
+		const readOnlyButton = document.getElementById( 'readOnly' );
+		const simulateErrorButton = document.getElementById( 'simulateError' );
+
+		const SAMPLE_READ_ONLY_LOCK_ID = 'Integration Sample';
+
+		class App extends React.Component {
+			constructor( props ) {
+				super( props );
+
+				this.state = {
+					documents: [ editorContent ],
+					documentID: 0,
+					isLoading: true
+				}
+			}
+
+			render() {
+				// Simulate the delay before loading the editor.
+				setTimeout( () => {
+					this.setState( { isLoading: false } );
+				}, 2000 );
+
+				const placeholderElement = React.createElement( 'i', null, 'LOADING SIMULATION...');
+
+				const editorElement = React.createElement( CKEditor.CKEditor, {
+					editor: ClassicEditor,
+					data: this.state.documents[ this.state.documentID ],
+					id: this.state.documentID,
+					onReady: editor => {
+						window.editor = editor;
+
+						console.log( 'event: onReady' );
+						console.log( 'Editor is ready to use! You can use "editor" variable to play with it.' );
+
+						readOnlyButton.disabled = false;
+						simulateErrorButton.disabled = false;
+						previousDocumentIDButton.disabled = this.state.documentID === 0;
+
+						editor.ui.view.listenTo( simulateErrorButton, 'click', () => {
+							setTimeout( () => {
+								const err = new Error( 'foo' );
+								err.context = editor;
+								err.is = () => true;
+
+								throw err;
+							} );
+						} );
+
+						editor.ui.view.listenTo( nextDocumentIDButton, 'click', () => {
+							this.setState( {
+								documentID: this.state.documentID + 1,
+								documents: this.state.documents.length < this.state.documentID + 1 ?
+									this.state.documents :
+									[ ...this.state.documents, editorContent ]
+							} )
+						} );
+
+						editor.ui.view.listenTo( previousDocumentIDButton, 'click', () => {
+							this.setState( { documentID: Math.max( this.state.documentID - 1, 0 ) } )
+						} );
+
+						editor.ui.view.listenTo( readOnlyButton, 'click', () => {
+							if ( editor.isReadOnly ) {
+								editor.disableReadOnlyMode( SAMPLE_READ_ONLY_LOCK_ID );
+								readOnlyButton.innerText = 'Switch to read-only mode';
+							} else {
+								editor.enableReadOnlyMode( SAMPLE_READ_ONLY_LOCK_ID );
+								readOnlyButton.innerText = 'Switch to editable mode';
+							}
+						} );
+					},
+					onChange: ( event, editor ) => {
+						this.updateData();
+
+						console.log( 'event: onChange', { event, editor } );
+					},
+
+					onBlur: ( event, editor ) => {
+						console.log( 'event: onBlur', { event, editor } );
+					},
+					onFocus: ( event, editor ) => {
+						console.log( 'event: onFocus', { event, editor } );
+					}
+				} );
+
+				return React.createElement(
+					React.Fragment,
+					null,
+					this.state.isLoading ?
+						placeholderElement :
+						editorElement
+				);
+			}
+
+			updateData() {
+				this.setState( {
+					documents: this.state.documents.map( ( data, index ) => {
+						if ( index === this.state.documentID ) {
+							return editor.getData();
+						}
+
+						return data;
+					} )
+				} );
+			}
+		}
+
+		const editorContent = `
+<h2>Sample</h2>
+<p>This is an instance of the <a href="https://ckeditor.com/docs/ckeditor5/latest/builds/guides/overview.html#classic-editor">classic editor build</a>.</p>
+<figure class="image">
+	<img src="./sample.jpg" alt="CKEditor 5 Sample image." />
+</figure>
+<p>You can use this sample to validate whether your <a href="https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/custom-builds.html">custom build</a> works fine.</p>
+`;
+
+		document.addEventListener( 'DOMContentLoaded', () => {
+			ReactDOM
+				.createRoot( document.getElementById( 'root' ) )
+				.render( React.createElement( React.StrictMode, null, React.createElement( App ) ) );
+		} );
+	</script>
+</body>
+
+</html>

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -19,8 +19,7 @@ export default class CKEditor extends React.Component {
 		super( props );
 
 		/**
-		 * While cleanup from destroying an editor is in progress, it contains a promise that resolves when cleanup is complete.
-		 * Otherwise it contains null.
+		 * Contains a promise that resolves when the editor destruction is finished.
 		 *
 		 * @type {Promise|null}
 		 */
@@ -225,6 +224,8 @@ export default class CKEditor extends React.Component {
 	 * @returns {Promise}
 	 */
 	async _destroyEditor() {
+		await this.editorDestructionInProgress;
+
 		this.editorDestructionInProgress = await new Promise( resolve => {
 			// It may happen during the tests that the watchdog instance is not assigned before destroying itself. See: #197.
 			/* istanbul ignore next */
@@ -236,8 +237,6 @@ export default class CKEditor extends React.Component {
 
 			resolve();
 		} );
-
-		this.editorDestructionInProgress = null;
 	}
 
 	/**

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -148,10 +148,6 @@ export default class CKEditor extends React.Component {
 			await this.editorDestructionInProgress;
 		}
 
-		if ( this.watchdog ) {
-			return;
-		}
-
 		if ( this.context instanceof ContextWatchdog ) {
 			this.watchdog = new EditorWatchdogAdapter( this.context );
 		} else {

--- a/tests/ckeditorcontext.jsx
+++ b/tests/ckeditorcontext.jsx
@@ -289,6 +289,29 @@ describe( '<CKEditorContext> Component', () => {
 			expect( wrapper.instance().contextWatchdog ).to.not.equal( null );
 		} );
 
+		it( 'should destroy the old editor watchdog instance and create a new one after restarting the context', async () => {
+			wrapper = mount(
+				<CKEditorContext context={ ContextMock } id="1" isLayoutReady={ false }>
+					<CKEditor editor={ EditorMock } />
+				</CKEditorContext>
+			);
+
+			const { watchdog: firstWatchdog } = wrapper.childAt( 0 ).instance();
+
+			await new Promise( res => {
+				wrapper.setProps( {
+					onReady: res,
+					isLayoutReady: true
+				} );
+			} );
+
+			const { watchdog: secondWatchdog } = wrapper.childAt( 0 ).instance();
+
+			expect( firstWatchdog ).to.equal( null );
+			expect( secondWatchdog ).to.not.equal( null );
+			expect( secondWatchdog._contextWatchdog.state ).to.equal( 'ready' );
+		} );
+
 		it( 'should not re-render the component if layout is not ready after initialization', async () => {
 			const oldContext = await new Promise( res => {
 				wrapper = mount(

--- a/tests/ckeditorcontext.jsx
+++ b/tests/ckeditorcontext.jsx
@@ -289,7 +289,7 @@ describe( '<CKEditorContext> Component', () => {
 			expect( wrapper.instance().contextWatchdog ).to.not.equal( null );
 		} );
 
-		it( 'should destroy the old editor watchdog instance and create a new one after restarting the context', async () => {
+		it( 'should not create the component watchdog if layout is not ready', async () => {
 			wrapper = mount(
 				<CKEditorContext context={ ContextMock } id="1" isLayoutReady={ false }>
 					<CKEditor editor={ EditorMock } />
@@ -297,6 +297,8 @@ describe( '<CKEditorContext> Component', () => {
 			);
 
 			const { watchdog: firstWatchdog } = wrapper.childAt( 0 ).instance();
+
+			expect( firstWatchdog ).to.equal( null );
 
 			await new Promise( res => {
 				wrapper.setProps( {
@@ -307,7 +309,6 @@ describe( '<CKEditorContext> Component', () => {
 
 			const { watchdog: secondWatchdog } = wrapper.childAt( 0 ).instance();
 
-			expect( firstWatchdog ).to.equal( null );
 			expect( secondWatchdog ).to.not.equal( null );
 			expect( secondWatchdog._contextWatchdog.state ).to.equal( 'ready' );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed the component initialization procedure to enforce cleanup completion before subsequent editor initialization. Closes #321. Closes #338.

Thanks to @corymharper.

---

Base PR: https://github.com/ckeditor/ckeditor5-react/pull/342.
