### PR TITLE
Added `watchdogConfig` property that allows defining configuration for the Watchdog

### DIFF
--- a/sample/index.html
+++ b/sample/index.html
@@ -49,6 +49,9 @@
 				return React.createElement( CKEditor.CKEditor, {
 					editor: ClassicEditor,
 					data: this.state.documents[ this.state.documentID ],
+					watchdogConfig: {
+						crashNumberLimit: 10
+					},
 					id: this.state.documentID,
 					onReady: editor => {
 						window.editor = editor;

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -388,6 +388,7 @@ CKEditor.propTypes = {
 	editor: PropTypes.func.isRequired,
 	data: PropTypes.string,
 	config: PropTypes.object,
+	watchdogConfig: PropTypes.object,
 	onChange: PropTypes.func,
 	onReady: PropTypes.func,
 	onFocus: PropTypes.func,

--- a/src/ckeditor.jsx
+++ b/src/ckeditor.jsx
@@ -153,7 +153,7 @@ export default class CKEditor extends React.Component {
 		if ( this.context instanceof ContextWatchdog ) {
 			this.watchdog = new EditorWatchdogAdapter( this.context );
 		} else {
-			this.watchdog = new CKEditor._EditorWatchdog( this.props.editor );
+			this.watchdog = new CKEditor._EditorWatchdog( this.props.editor, this.props.watchdogConfig );
 		}
 
 		this.watchdog.setCreator( ( el, config ) => this._createEditor( el, config ) );
@@ -302,7 +302,7 @@ export default class CKEditor extends React.Component {
  */
 class EditorWatchdogAdapter {
 	/**
-	 * @param {ContextWatchdog} contextWatchdog The context watchdog instance that will be wrapped into wditor watchdog API.
+	 * @param {ContextWatchdog} contextWatchdog The context watchdog instance that will be wrapped into editor watchdog API.
 	 */
 	constructor( contextWatchdog ) {
 		this._contextWatchdog = contextWatchdog;

--- a/src/ckeditorcontext.jsx
+++ b/src/ckeditorcontext.jsx
@@ -55,7 +55,7 @@ export default class CKEditorContext extends React.Component {
 	}
 
 	async _initializeContextWatchdog( config ) {
-		this.contextWatchdog = new ContextWatchdog( this.props.context );
+		this.contextWatchdog = new ContextWatchdog( this.props.context, this.props.watchdogConfig );
 
 		this.contextWatchdog.on( 'error', ( _, errorEvent ) => {
 			this.props.onError( errorEvent.error, {

--- a/src/ckeditorcontext.jsx
+++ b/src/ckeditorcontext.jsx
@@ -97,6 +97,7 @@ CKEditorContext.propTypes = {
 	id: PropTypes.string,
 	isLayoutReady: PropTypes.bool,
 	context: PropTypes.func,
+	watchdogConfig: PropTypes.object,
 	config: PropTypes.object,
 	onReady: PropTypes.func,
 	onError: PropTypes.func

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -272,7 +272,7 @@ describe( '<CKEditor> Component', () => {
 			} );
 
 			expect( constructorSpy.called ).to.equal( true );
-			expect( constructorSpy.firstCall.args[ 1 ] ).to.equal( myWatchdogConfig );
+			expect( constructorSpy.firstCall.args[ 1 ] ).to.deep.equal( myWatchdogConfig );
 
 			CKEditor._EditorWatchdog = EditorWatchdog;
 		} );

--- a/tests/ckeditor.jsx
+++ b/tests/ckeditor.jsx
@@ -252,6 +252,30 @@ describe( '<CKEditor> Component', () => {
 
 			CKEditor._EditorWatchdog = EditorWatchdog;
 		} );
+
+		it( 'passes the watchdog config to the watchdog feature', async () => {
+			const EditorWatchdog = CKEditor._EditorWatchdog;
+			const constructorSpy = sinon.spy();
+			const myWatchdogConfig = { crashNumberLimit: 678 };
+
+			class CustomEditorWatchdog extends EditorWatchdog {
+				constructor( ...args ) {
+					super( ...args );
+					constructorSpy( ...args );
+				}
+			}
+
+			CKEditor._EditorWatchdog = CustomEditorWatchdog;
+
+			await new Promise( res => {
+				wrapper = mount( <CKEditor editor={ Editor } onReady={ res } watchdogConfig={ myWatchdogConfig }/> );
+			} );
+
+			expect( constructorSpy.called ).to.equal( true );
+			expect( constructorSpy.firstCall.args[ 1 ] ).to.equal( myWatchdogConfig );
+
+			CKEditor._EditorWatchdog = EditorWatchdog;
+		} );
 	} );
 
 	describe( 'properties', () => {

--- a/tests/ckeditorcontext.jsx
+++ b/tests/ckeditorcontext.jsx
@@ -39,6 +39,20 @@ describe( '<CKEditorContext> Component', () => {
 			expect( component.contextWatchdog ).to.be.instanceOf( ContextWatchdog );
 		} );
 
+		it( 'should pass the watchdog config to the ContextWatchdog', async () => {
+			const myWatchdogConfig = { crashNumberLimit: 678 };
+
+			await new Promise( res => {
+				wrapper = mount( <CKEditorContext context={ ContextMock } onReady={ res } watchdogConfig={ myWatchdogConfig }/> );
+			} );
+
+			const component = wrapper.instance();
+
+			expect( component.contextWatchdog ).to.be.an( 'object' );
+			expect( component.contextWatchdog ).to.be.instanceOf( ContextWatchdog );
+			expect( component.contextWatchdog._crashNumberLimit ).to.equal( 678 );
+		} );
+
 		it( 'should not create anything if the layout is not ready', async () => {
 			wrapper = mount( <CKEditorContext context={ ContextMock } isLayoutReady={ false }/> );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added the `watchdogConfig` property that allows defining configuration for the [Watchdog](https://ckeditor.com/docs/ckeditor5/latest/features/watchdog.html) feature. Closes #360.

---

### Additional information

Related docs PR: ckeditor/ckeditor5#13517
