### PR TITLE
CKEditor: handle being torn down before initialization

### DIFF
--- a/src/ckeditor.tsx
+++ b/src/ckeditor.tsx
@@ -166,6 +166,15 @@ export default class CKEditor<TEditor extends Editor> extends React.Component<Pr
 	 * @param config CKEditor 5 editor configuration.
 	 */
 	private _createEditor( element: HTMLElement | string | Record<string, string>, config: EditorConfig ): Promise<TEditor> {
+		if ( !element ) {
+			// In our case, the only way this element is falsy is if we're caught in
+			// the middle of tearing down this component. This isn't really an error,
+			// so it doesn't make sense to reject the promise-- that would make the
+			// watchdog explode anyway. Just create an empty editor so the watchdog
+			// can shutdown properly.
+			return this.props.editor.create( '', {} );
+		}
+
 		return this.props.editor.create( element as HTMLElement, config )
 			.then( editor => {
 				if ( 'disabled' in this.props ) {


### PR DESCRIPTION
It's easy, particularly in tests, to end up rendering the editor only to then quickly change a prop that causes it to no longer render. It's possible for this to happen quickly enough that `_initializeEditor()` hasn't finished running yet, thus ending up in `_createEditor()` with a null `element`. That ends up causing CKEditor itself to throw an exception, and ends up not defining the editor, which then makes the watchdog throw an exception. The latter error is not catchable in an error boundary due to its asynchronous nature.

Fix this by making `_createEditor()` a little more defensive: make sure we have an element before bothering to create an editor. If we don't have one, we know we're in the midst of a teardown, so create a dummy editor so the watchdog has something to destroy.

This might be related to #351, but I'm not certain.