### PR TITLE
Fixed using `CI` env variable instead of `TRAVIS` in `getBrowsers()`.

### DIFF
--- a/scripts/utils/getkarmaconfig.js
+++ b/scripts/utils/getkarmaconfig.js
@@ -186,7 +186,7 @@ function getBrowsers( browsers ) {
 			return browser;
 		}
 
-		return process.env.TRAVIS ? 'CHROME_CI' : 'CHROME_LOCAL';
+		return process.env.CI ? 'CHROME_CI' : 'CHROME_LOCAL';
 	} );
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed using `CI` env variable instead of `TRAVIS` in `getBrowsers()`. See #408.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
