### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@ckeditor/ckeditor5-watchdog": ">=37.0.0"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",


### PR DESCRIPTION
Other: Updated the required version of Node.js to 18 when developing the repository. See ckeditor/ckeditor5#14924.