### PR TITLE
Allow creation for context without a contextwatchdog

### DIFF
--- a/src/ckeditorcontext.tsx
+++ b/src/ckeditorcontext.tsx
@@ -67,6 +67,9 @@ export default class CKEditorContext<TContext extends Context = Context> extends
 	}
 
 	private async _initializeContextWatchdog( config?: ContextConfig ): Promise<void> {
+		if ( this.props.disableWatchdog ) {
+			return;
+		}
 		this.contextWatchdog = new ContextWatchdog( this.props.context!, this.props.watchdogConfig );
 
 		this.contextWatchdog.on( 'error', ( _, errorEvent ) => {
@@ -107,6 +110,7 @@ export default class CKEditorContext<TContext extends Context = Context> extends
 		id: PropTypes.string,
 		isLayoutReady: PropTypes.bool,
 		context: PropTypes.func as unknown as Validator<{ create( ...args: any ): Promise<any> } | undefined>,
+		disableWatchdog: PropTypes.bool,
 		watchdogConfig: PropTypes.object,
 		config: PropTypes.object,
 		onReady: PropTypes.func,
@@ -116,6 +120,7 @@ export default class CKEditorContext<TContext extends Context = Context> extends
 
 interface Props<TContext extends Context> extends InferProps<typeof CKEditorContext.propTypes> {
 	context?: { create( ...args: any ): Promise<TContext> };
+	disableWatchdog?: boolean;
 	watchdogConfig?: WatchdogConfig;
 	config?: ContextConfig;
 	onReady?: ( context: Context ) => void; // TODO this should accept TContext (after ContextWatchdog release).

--- a/tests/ckeditorcontext.jsx
+++ b/tests/ckeditorcontext.jsx
@@ -53,6 +53,16 @@ describe( '<CKEditorContext> Component', () => {
 			expect( component.contextWatchdog._crashNumberLimit ).to.equal( 678 );
 		} );
 
+		it( 'should not create a context watchdog if disableWatchdog flag is passed to config', async () => {
+			await new Promise( res => {
+				wrapper = mount( <CKEditorContext context={ ContextMock } onReady={ res } disableWatchdog={true}/> );
+			} );
+
+			const component = wrapper.instance();
+
+			expect( component.contextWatchdog ).to.be.null;
+		} );
+
 		it( 'should not create anything if the layout is not ready', async () => {
 			wrapper = mount( <CKEditorContext context={ ContextMock } isLayoutReady={ false }/> );
 


### PR DESCRIPTION
Feature (ckeditor5-react): Allowing creation of a ckeditor5 context without a context watcdhog Closes #409.