### PR TITLE
Quick rerendering causes editor issues

### DIFF
--- a/demo-multiroot-react-18/src/App.tsx
+++ b/demo-multiroot-react-18/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { StrictMode, useState } from 'react';
 import MultiRootEditorDemo from './MultiRootEditorDemo';
 import MultiRootEditorRichDemo from './MultiRootEditorRichDemo';
 import ContextMultiRootEditorDemo from './ContextMultiRootEditorDemo';
@@ -43,7 +43,7 @@ export default function App(): JSX.Element {
 	};
 
 	return (
-		<>
+		<StrictMode>
 			<h1>CKEditor 5 – useMultiRootEditor – development sample</h1>
 
 			<div className="buttons" style={ { textAlign: 'center' } }>
@@ -69,6 +69,6 @@ export default function App(): JSX.Element {
 				</button>
 			</div>
 			{ renderDemo() }
-		</>
+		</StrictMode>
 	);
 }

--- a/src/hooks/useEditorEffect.ts
+++ b/src/hooks/useEditorEffect.ts
@@ -1,0 +1,23 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { DependencyList } from 'react';
+import type { LifeCycleElementSemaphore } from '../lifecycle/LifeCycleElementSemaphore';
+import { useInstantEffect } from './useInstantEffect';
+
+/**
+ * `useEffect` alternative but executed after mounting of editor.
+ */
+export const useEditorEffect = <R>(
+	semaphore: LifeCycleElementSemaphore<R> | null,
+	fn: ( mountResult: R ) => void,
+	deps: DependencyList
+): void => {
+	useInstantEffect( () => {
+		if ( semaphore ) {
+			semaphore.runAfterMount( fn );
+		}
+	}, [ semaphore, ...deps ] );
+};

--- a/src/hooks/useInstantEditorEffect.ts
+++ b/src/hooks/useInstantEditorEffect.ts
@@ -10,7 +10,7 @@ import { useInstantEffect } from './useInstantEffect';
 /**
  * `useEffect` alternative but executed after mounting of editor.
  */
-export const useEditorEffect = <R>(
+export const useInstantEditorEffect = <R>(
 	semaphore: LifeCycleElementSemaphore<R> | null,
 	fn: ( mountResult: R ) => void,
 	deps: DependencyList

--- a/src/hooks/useInstantEffect.ts
+++ b/src/hooks/useInstantEffect.ts
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { useRef, type DependencyList } from 'react';
+import { shallowCompareArrays } from '../utils/shallowCompareArrays';
+
+/**
+ * Triggers an effect immediately if the dependencies change (during rendering of component).
+ *
+ * @param fn The effect function to execute.
+ * @param deps The dependency list.
+ */
+export const useInstantEffect = ( fn: VoidFunction, deps: DependencyList ): void => {
+	const prevDeps = useRef<any>( null );
+
+	if ( !shallowCompareArrays( prevDeps.current, deps ) ) {
+		prevDeps.current = [ ...deps ];
+		fn();
+	}
+};

--- a/src/hooks/useRefSafeCallback.ts
+++ b/src/hooks/useRefSafeCallback.ts
@@ -1,0 +1,20 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { useCallback, useRef } from 'react';
+
+/**
+ * Hook that guarantees that returns constant reference for passed function.
+ * Useful for preventing closures from capturing cached scope variables (avoiding the stale closure problem).
+ */
+export const useRefSafeCallback = <A extends Array<unknown>, R>( fn: ( ...args: A ) => R ): typeof fn => {
+	const callbackRef = useRef<typeof fn>();
+	callbackRef.current = fn;
+
+	return useCallback(
+		( ...args: A ): R => ( callbackRef.current as typeof fn )( ...args ),
+		[]
+	);
+};

--- a/src/lifecycle/LifeCycleEditorSemaphore.ts
+++ b/src/lifecycle/LifeCycleEditorSemaphore.ts
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { Editor } from '@ckeditor/ckeditor5-core';
+import type { EditorWatchdog } from '@ckeditor/ckeditor5-watchdog';
+
+import type { EditorWatchdogAdapter } from '../ckeditor';
+import type { LifeCycleElementSemaphore } from './LifeCycleElementSemaphore';
+
+export type EditorSemaphoreMountResult<TEditor extends Editor> = {
+
+	/**
+	 * Holds the instance of the editor if `props.disableWatchdog` is set to true.
+	 */
+	instance: TEditor;
+
+	/**
+	 * An instance of EditorWatchdog or an instance of EditorWatchdog-like adapter for ContextWatchdog.
+	 * It holds the instance of the editor under `this.watchdog.editor` if `props.disableWatchdog` is set to false.
+	 */
+	watchdog: EditorWatchdog<TEditor> | EditorWatchdogAdapter<TEditor> | null;
+};
+
+export type LifeCycleEditorSemaphore<TEditor extends Editor> = LifeCycleElementSemaphore<
+	EditorSemaphoreMountResult<TEditor>
+>;

--- a/src/lifecycle/LifeCycleElementSemaphore.ts
+++ b/src/lifecycle/LifeCycleElementSemaphore.ts
@@ -1,0 +1,294 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { createDefer, type Defer } from '../utils/defer';
+import { once } from '../utils/once';
+
+/**
+ * This class is utilized to pause the initialization of an editor when another instance is already present on a specified element.
+ * It is engineered to address the following issues:
+ *
+ *	* Rapid changes in component properties often lead to the re-initialization of the editor, which can trigger
+ *	  the `editor-source-element-already-used` exception. This occurs because the editor is still in the process of initializing
+ *	  when the component decides to destroy it. This semaphore waits for the editor to fully initialize before destroying it, thereby
+ *	  allowing a new instance of the editor to be attached to the specified element.
+ *
+ *	* Rapid mounting and unmounting in strict mode frequently results in the `editor-source-element-already-used` exception
+ *	  being thrown by the editor. This is due to React reusing the underlying DOM element during the mounting and unmounting of components
+ *	  (especially if the same component is being mounted and unmounted). Consequently, a race condition arises. The first render begins to
+ *	  attach the editor (in async mode), and shortly thereafter, it is destroyed and a new instance of the component is initialized.
+ *	  This semaphore, by utilizing a static semaphores promises map, retains information about whether the element is used by a previous
+ *	  instance of the editor and resumes execution when it is freed.
+ *
+ *	* The process involves starting up many editors that are no longer needed and are immediately removed in the following rerenders.
+ *	  This can cause the editor’s initialization performance to slow down. The initialization of the editor is skipped when numerous
+ *	  rerenders occur within a short time-frame while using this semaphore. An example of this could be a situation with 4 rerenders
+ *	  occurring within a 10ms period. This semaphore will likely batch these calls, and instead of initializing 4 editors, only 2 will be
+ *	  initialized (the first and the last one).
+ */
+export class LifeCycleElementSemaphore<R> {
+	/**
+	 * This is a map of elements associated with promises. It informs the semaphore that the underlying HTML element, used as a key,
+	 * is currently in use by another editor. Each element is assigned a promise, which allows for the easy chaining of new
+	 * editor instances on an element that is already in use by another instance. The process works as follows:
+	 *
+	 * 	1. If an element is being used by an editor, then the initialization of a new editor
+	 * 	   instance is chained using the `.then()` method of the Promise.
+	 *
+	 * 	2. If the editor associated with the underlying element is destroyed, then `Promise.resolve()` is called
+	 * 	   and the previously assigned `.then()` editor callback is executed.
+	 *
+	 *  @see {@link #lock} for more detailed information on the implementation.
+	 */
+	private static readonly _semaphores = new Map<HTMLElement, Promise<void>>();
+
+	/**
+	 * This should define async methods for initializing and destroying the editor.
+	 * Essentially, it's an async version of basic React lifecycle methods like `componentDidMount`, `componentWillUnmount`.
+	 *
+	 * 	* Result of {@link LifeCycleAsyncOperators#mount} method is passed to {@link LifeCycleAsyncOperators#unmount} as an argument.
+	 */
+	private readonly _lifecycle: LifeCycleAsyncOperators<R>;
+
+	/**
+	 * This is the element instance that the editor uses for mounting. This element should contain the `ckeditorInstance` member
+	 * once the editor has been successfully mounted to it. The semaphore ensures that a new instance of the editor, which will
+	 * be assigned to this element by the {@link #_lifecycle:mount} method, will always be initialized after the successful
+	 * destruction of the underlying `ckeditorInstance` that was previously mounted on this element.
+	 */
+	private readonly _element: HTMLElement;
+
+	/**
+	 * This is the lock mechanism utilized by the {@link #lock} and {@link #release} methods.
+	 *
+	 * 	* If the editor is not yet mounted and is awaiting mounting (for instance, when another editor is
+	 * 	  occupying the element), then it is null.
+	 *
+	 * 	* When the editor is mounted on the element, this variable holds an unresolved promise that will be
+	 * 	  resolved after the editor is destroyed.
+	 *
+	 * 	* Once the editor is destroyed (and it was previously mounted), the promise is resolved.
+	 */
+	private _releaseLock: Defer<void> | null = null;
+
+	/**
+	 * This is the result of the {@link #_lifecycle:mount} function. This value should be reset to `null`
+	 * once the semaphore is released. It is utilized to store certain data that must be removed following
+	 * the destruction of the editor. This data may include the editor's instance, the assigned watchdog,
+	 * or handles for additional window listeners.
+	 */
+	private _value: R | null = null;
+
+	/**
+	 * This is a list of callbacks that are triggered if the semaphore {@link #_lifecycle:mount} method executes successfully.
+	 * It is utilized in scenarios where we need to assign certain properties to an editor that is currently in the process of mounting.
+	 * An instance of such usage could be two-way binding. We aim to prevent the loss of all `setData` calls if the editor has not
+	 * yet been mounted, therefore these calls will be executed immediately following the completion of the mounting process.
+	 */
+	private _afterMountCallbacks: Array<LifeCycleAfterMountCallback<R>> = [];
+
+	/**
+	 * This represents the actual mounting state of the semaphore. It is primarily used by the {@link #release} method to
+	 * determine whether the initialization of the editor should be skipped or, if the editor is already initialized, the editor
+	 * should be destroyed.
+	 *
+	 * 	* If `destroyedBeforeInitialization` is true, then the {@link #release} method was invoked before the editor began to mount.
+	 * 	  This often occurs in strict mode when we assign a promise to the {@link LifeCycleEditorElementSemaphore#_semaphores} map
+	 * 	  and the assigned `mount` callback has not yet been called. In this scenario, it is safe to skip the initialization of the editor
+	 * 	  and simply release the semaphore.
+	 *
+	 *	* If `mountingInProgress` is a Promise, then the {@link #release} method was invoked after the initialization of the editor and
+	 	  the editor must be destroyed before the semaphore is released.
+	*/
+	private _state: LifeCycleState<R> = {
+		destroyedBeforeInitialization: false,
+		mountingInProgress: null
+	};
+
+	constructor( element: HTMLElement, lifecycle: LifeCycleAsyncOperators<R> ) {
+		this._element = element;
+		this._lifecycle = lifecycle;
+		this._lock();
+	}
+
+	/**
+	 * Getter for {@link #_value}.
+	 */
+	public get value(): R | null {
+		return this._value;
+	}
+
+	/**
+	 * Occasionally, the Watchdog restarts the editor instance, resulting in a new instance being assigned to the semaphore.
+	 * In terms of race conditions, it's generally safer to simply override the semaphore value rather than recreating it
+	 * with a different one.
+	 */
+	public unsafeSetValue( value: R ): void {
+		this._value = value;
+
+		this._afterMountCallbacks.forEach( callback => callback( value ) );
+		this._afterMountCallbacks = [];
+	}
+
+	/**
+	 * This registers a callback that will be triggered after the editor has been successfully mounted.
+	 *
+	 * 	* If the editor is already mounted, the callback will be executed immediately.
+	 *	* If the editor is in the process of mounting, the callback will be executed upon successful mounting.
+	* 	* If the editor is never mounted, the passed callback will not be executed.
+	* 	* If an exception is thrown within the callback, it will be re-thrown in the semaphore.
+	*/
+	public runAfterMount( callback: LifeCycleAfterMountCallback<R> ): void {
+		const { _value, _afterMountCallbacks } = this;
+
+		if ( _value ) {
+			callback( _value );
+		} else {
+			_afterMountCallbacks.push( callback );
+		}
+	}
+
+	/**
+	 * This method is used to inform other components that the {@link #_element} will be used by the editor,
+	 * which is initialized by the {@link #_lifecycle} methods.
+	 *
+	 * 	* If an editor is already present on the provided element, the initialization of the current one
+	 * 	  will be postponed until the previous one is destroyed.
+	 *
+	 * 	* If the element is empty and does not have an editor attached to it, the currently locked editor will
+	 * 	  be mounted immediately.
+	 *
+	 * After the successful initialization of the editor and the assignment of the {@link #_value} member,
+	 * the `onReady` lifecycle method is called.
+	 *
+	 * *Important note:*
+	 *
+	 * It’s really important to keep this method *sync*. If we make this method *async*, it won’t work well because
+	 * it will cause problems when we’re trying to set up the {@link LifeCycleEditorElementSemaphore#_semaphores} map entries.
+	 */
+	private _lock(): void {
+		const { _semaphores } = LifeCycleElementSemaphore;
+		const { _state, _element, _lifecycle } = this;
+
+		// This promise signifies that the previous editor is still attached to the current element.
+		// Upon successful resolution, it will indicate that it is safe to assume that the element has
+		// no assigned editor instance and can be reinitialized.
+		const prevElementSemaphore = _semaphores.get( _element ) || Promise.resolve( null );
+
+		// This is a lock that will be resolved after the `release` method is called. Due to this lock,
+		// the promise will never be resolved until the editor is destroyed.
+		const releaseLock = createDefer();
+		this._releaseLock = releaseLock;
+
+		// This is the initialization of the editor that occurs after the previous editor has been detached from the specified element.
+		//
+		// If the `release` method was called before the initialization of the current editor instance, then it will be skipped.
+		// This situation occurs quite frequently when we have three or more rerenders in a row, and it doesn't make sense to initialize
+		// the second editor because it will be overridden anyway by the third one.
+		const newElementSemaphore = prevElementSemaphore
+			.then( () => {
+				if ( _state.destroyedBeforeInitialization ) {
+					return Promise.resolve( undefined );
+				}
+
+				// This variable will be used later in the `release` method to determine
+				// whether the editor is being destroyed prior to initialization.
+				_state.mountingInProgress = _lifecycle.mount().then( mountResult => {
+					if ( mountResult ) {
+						this.unsafeSetValue( mountResult );
+					}
+
+					return mountResult;
+				} );
+
+				return _state.mountingInProgress;
+			} )
+			.then( async mountResult => {
+				// Everything is fine, all ready callback might be fired here.
+				if ( mountResult && _lifecycle.afterMount ) {
+					await _lifecycle.afterMount( {
+						element: _element,
+						mountResult
+					} );
+				}
+			} )
+
+			// It will be released after destroying of editor by the {@link #_release method}.
+			.then( () => releaseLock.promise )
+
+			// Prevent hanging of semaphore during mount, just assume that everything is fine
+			.catch( error => {
+				console.error( 'Semaphore mounting error:', error );
+			} )
+
+			// Remove semaphore from map if released.
+			.then( () => {
+				if ( _semaphores.get( _element ) === newElementSemaphore ) {
+					_semaphores.delete( _element );
+				}
+			} );
+
+		_semaphores.set( _element, newElementSemaphore );
+	}
+
+	/**
+	 * Inverse of {@link #_lock} method that tries to destroy attached editor.
+	 *
+	 * 	* If editor is being already attached to element (or is in attaching process) then after fully initialization of editor
+	 * 	  destroy is performed and semaphore is released. The {@link #_lifecycle} unmount method is called.
+	 *
+	 * 	* If editor is being destroyed before initialization then it does nothing but sets `destroyedBeforeInitialization` flag that
+	 * 	  will be later checked by {@link #_lock} method in initialization. The {@link #_lifecycle} unmount method is not called.
+	 *
+	 * *Important note:*
+	 *
+	 * It’s really important to keep this method *sync*. If we make this method *async*, it won’t work well because
+	 * it will cause problems when we’re trying to set up the {@link LifeCycleEditorElementSemaphore#_semaphores} map entries.
+	 */
+	public readonly release = once( () => {
+		const { _releaseLock, _state, _element, _lifecycle } = this;
+
+		if ( _state.mountingInProgress ) {
+			_state.mountingInProgress
+				.then( () => _lifecycle.unmount( {
+					element: _element,
+
+					// Mount result might be overridden by watchdog during restart so use instance variable.
+					mountResult: this.value!
+				} ) )
+
+				// Prevent hanging of semaphore during unmount, just assume that everything is fine
+				.catch( error => {
+					console.error( 'Semaphore unmounting error:', error );
+				} )
+
+				.then( _releaseLock!.resolve )
+				.then( () => {
+					this._value = null;
+				} );
+		} else {
+			_state.destroyedBeforeInitialization = true;
+			_releaseLock!.resolve();
+		}
+	} );
+}
+
+export type LifeCycleAfterMountCallback<R> = ( mountResult: R ) => void;
+
+type LifeCycleState<R> = {
+	destroyedBeforeInitialization: boolean;
+	mountingInProgress: Promise<R> | null;
+};
+
+type LifeCyclePostMountAttrs<R> = {
+	element: HTMLElement;
+	mountResult: R;
+};
+
+type LifeCycleAsyncOperators<R> = {
+	mount: () => Promise<R>;
+	afterMount?: ( result: LifeCyclePostMountAttrs<R> ) => Promise<void> | void;
+	unmount: ( result: LifeCyclePostMountAttrs<R> ) => Promise<void>;
+};

--- a/src/lifecycle/useLifeCycleSemaphoreSyncRef.tsx
+++ b/src/lifecycle/useLifeCycleSemaphoreSyncRef.tsx
@@ -1,0 +1,92 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { useRef, useState, type RefObject } from 'react';
+import type { LifeCycleElementSemaphore, LifeCycleAfterMountCallback } from './LifeCycleElementSemaphore';
+
+/**
+ * When using the `useState` approach, a new instance of the semaphore must be set based on the previous
+ * one within the `setState` callback, as shown in this example:
+ *
+ * 		setState( prevSemaphore => ... )
+ *
+ * The issue arises from the uncertainty of whether React has batched and cancelled some `setState` calls.
+ * This means that setting the state with a semaphore three times might result in the collapsing of these three calls into a single one.
+ *
+ * Although this may not seem like a significant issue in theory, it can lead to a multitude of minor issues in practice that may
+ * generate race conditions. This is because semaphores handle batching independently.
+ *
+ * A solution involving refs is safer in terms of preserving object references. In other words, `semaphoreRef.current` is guaranteed to
+ * always point to the most recent instance of the semaphore.
+ */
+export const useLifeCycleSemaphoreSyncRef = <R extends object>(): LifeCycleSemaphoreSyncRefResult<R> => {
+	const semaphoreRef = useRef<LifeCycleElementSemaphore<R> | null>( null );
+	const [ revision, setRevision ] = useState( () => Date.now() );
+
+	const refresh = () => {
+		setRevision( Date.now() );
+	};
+
+	const release = ( rerender: boolean = true ) => {
+		if ( semaphoreRef.current ) {
+			semaphoreRef.current.release();
+			semaphoreRef.current = null;
+		}
+
+		if ( rerender ) {
+			setRevision( Date.now() );
+		}
+	};
+
+	const unsafeSetValue = ( value: R ) => {
+		semaphoreRef.current?.unsafeSetValue( value );
+		refresh();
+	};
+
+	const runAfterMount = ( callback: LifeCycleAfterMountCallback<R> ) => {
+		if ( semaphoreRef.current ) {
+			semaphoreRef.current.runAfterMount( callback );
+		}
+	};
+
+	const replace = ( newSemaphore: () => LifeCycleElementSemaphore<R> ) => {
+		release( false );
+		semaphoreRef.current = newSemaphore();
+
+		refresh();
+		runAfterMount( refresh );
+	};
+
+	const createAttributeRef = <K extends keyof R>( key: K ): RefObject<R[ K ]> => ( {
+		get current() {
+			if ( !semaphoreRef.current || !semaphoreRef.current.value ) {
+				return null;
+			}
+
+			return semaphoreRef.current.value[ key ];
+		}
+	} );
+
+	return {
+		get current() {
+			return semaphoreRef.current;
+		},
+		revision,
+		createAttributeRef,
+		unsafeSetValue,
+		release,
+		replace,
+		runAfterMount
+	};
+};
+
+export type LifeCycleSemaphoreSyncRefResult<R> = RefObject<LifeCycleElementSemaphore<R>> & {
+	revision: number;
+	unsafeSetValue: ( value: R ) => void;
+	runAfterMount: ( callback: LifeCycleAfterMountCallback<R> ) => void;
+	release: ( rerender?: boolean ) => void;
+	replace: ( newSemaphore: () => LifeCycleElementSemaphore<R> ) => void;
+	createAttributeRef: <K extends keyof R>( key: K ) => RefObject<R[ K ]>;
+};

--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -431,14 +431,12 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 		/>
 	);
 
-	useInstantEditorEffect( semaphore.current, () => {
-		semaphore.runAfterMount( ( { instance } ) => {
-			if ( props.disabled ) {
-				instance.enableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
-			} else {
-				instance.disableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
-			}
-		} );
+	useInstantEditorEffect( semaphore.current, ( { instance } ) => {
+		if ( props.disabled ) {
+			instance.enableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
+		} else {
+			instance.disableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
+		}
 	}, [ props.disabled ] );
 
 	useInstantEditorEffect( semaphore.current, ( { instance } ) => {

--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -31,7 +31,7 @@ import { overwriteObject } from './utils/overwriteObject';
 import { useRefSafeCallback } from './hooks/useRefSafeCallback';
 import { uniq } from './utils/uniq';
 import { overwriteArray } from './utils/overwriteArray';
-import { useEditorEffect } from './hooks/useEditorEffect';
+import { useInstantEditorEffect } from './hooks/useInstantEditorEffect';
 
 const REACT_INTEGRATION_READ_ONLY_LOCK_ID = 'Lock from React integration (@ckeditor/ckeditor5-react)';
 
@@ -431,7 +431,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 		/>
 	);
 
-	useEditorEffect( semaphore.current, () => {
+	useInstantEditorEffect( semaphore.current, () => {
 		semaphore.runAfterMount( ( { instance } ) => {
 			if ( props.disabled ) {
 				instance.enableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
@@ -441,7 +441,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 		} );
 	}, [ props.disabled ] );
 
-	useEditorEffect( semaphore.current, ( { instance } ) => {
+	useInstantEditorEffect( semaphore.current, ( { instance } ) => {
 		// Editor should be only updated when the changes come from the integrator React application.
 		if ( shouldUpdateEditor.current ) {
 			shouldUpdateEditor.current = false;

--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -3,8 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-import React, { useState, useEffect, useRef, type Dispatch, type SetStateAction, useContext, useCallback } from 'react';
+import React, {
+	forwardRef, useState, useEffect, useRef, useContext, useCallback, memo,
+	type Dispatch, type SetStateAction, type RefObject
+} from 'react';
 
+import type { InlineEditableUIView } from '@ckeditor/ckeditor5-ui';
 import type { EditorConfig } from '@ckeditor/ckeditor5-core';
 import type { DocumentChangeEvent, Writer, RootElement } from '@ckeditor/ckeditor5-engine';
 
@@ -18,73 +22,96 @@ import type EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import { ContextWatchdogContext } from './ckeditorcontext';
 import { EditorWatchdogAdapter } from './ckeditor';
 
+import type { EditorSemaphoreMountResult } from './lifecycle/LifeCycleEditorSemaphore';
+
+import { useLifeCycleSemaphoreSyncRef, type LifeCycleSemaphoreSyncRefResult } from './lifecycle/useLifeCycleSemaphoreSyncRef';
+import { mergeRefs } from './utils/mergeRefs';
+import { LifeCycleElementSemaphore } from './lifecycle/LifeCycleElementSemaphore';
+import { overwriteObject } from './utils/overwriteObject';
+import { useRefSafeCallback } from './hooks/useRefSafeCallback';
+import { uniq } from './utils/uniq';
+import { overwriteArray } from './utils/overwriteArray';
+import { useInstantEffect } from './hooks/useInstantEffect';
+
 const REACT_INTEGRATION_READ_ONLY_LOCK_ID = 'Lock from React integration (@ckeditor/ckeditor5-react)';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
 const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns => {
-	const watchdog = useRef<EditorWatchdog | EditorWatchdogAdapter<MultiRootEditor> | null>( null );
+	const semaphoreElementRef = useRef<HTMLElement>( props.semaphoreElement || null );
+	const semaphore = useLifeCycleSemaphoreSyncRef<LifeCycleMountResult>();
 
-	const editorDestructionInProgress = useRef<Promise<void> | null>( null );
+	const editorRefs: LifeCycleSemaphoreRefs<MultiRootEditor> = {
+		watchdog: semaphore.createAttributeRef( 'watchdog' ),
+		instance: semaphore.createAttributeRef( 'instance' )
+	};
 
 	const context = useContext( ContextWatchdogContext );
 
-	// Current editor instance. It may change if the editor is re-initialized by the Watchdog after an error.
-	const [ editor, setEditor ] = useState<MultiRootEditor | null>( null );
+	// List of editor root elements.
+	const [ roots, setRoots ] = useState<Array<string>>( () => Object.keys( props.data ) );
 
 	// Current editor data. An object where each key is a root name and the value is the root content.
-	const [ data, setData ] = useState<Record<string, string>>( props.data );
+	const [ data, setData ] = useState<Record<string, string>>( { ...props.data } );
 
 	// Current roots attributes. An object where each key is a root name and the value is an object with root attributes.
-	const [ attributes, setAttributes ] = useState<Record<string, Record<string, unknown>>>( props.rootsAttributes || {} );
-
-	// Contains the JSX elements for each editor root.
-	const [ elements, setElements ] = useState<Array<JSX.Element>>( [] );
+	const [ attributes, setAttributes ] = useState<Record<string, Record<string, unknown>>>( { ...props.rootsAttributes } );
 
 	const shouldUpdateEditor = useRef<boolean>( true );
 
 	useEffect( () => {
-		const initEditor = async () => {
-			// When the component has been remounted it is crucial to wait for removing the old editor
-			// and cleaning the old state.
-			await editorDestructionInProgress.current;
+		const semaphoreElement = semaphoreElementRef.current;
 
-			if ( props.isLayoutReady !== false ) {
-				await _initializeEditor();
+		if ( !semaphoreElement || props.isLayoutReady === false ) {
+			return;
+		}
+
+		semaphore.replace( () => new LifeCycleElementSemaphore( semaphoreElement, {
+			mount: _initializeEditor,
+			afterMount: ( { mountResult } ) => {
+				const { onReady } = props;
+
+				if ( onReady && semaphoreElementRef.current !== null ) {
+					onReady( mountResult.instance );
+				}
+			},
+			unmount: async ( { element, mountResult } ) => {
+				const { onAfterDestroy } = props;
+
+				try {
+					await _destroyEditor( mountResult );
+
+					/**
+					 * Make sure that nothing left in actual editor element. There can be custom integrations that
+					 * appends something to container. Let's reset element every update cycle before mounting another
+					 * editor instance.
+					 */
+					element.innerHTML = '';
+				} finally {
+					/**
+					 * Broadcast information about destroying current instance. It is useful for removing duplicated
+					 * toolbars in decoupled editor mode.
+					 */
+					if ( onAfterDestroy ) {
+						onAfterDestroy( mountResult.instance );
+					}
+				}
 			}
-		};
-
-		initEditor();
+		} ) );
 
 		return () => {
-			_destroyEditor().then( () => {
-				editorDestructionInProgress.current = null;
-			} );
+			semaphore.release( false );
 		};
-	}, [ props.isLayoutReady ] );
+	}, [ props.id, props.isLayoutReady ] );
 
 	useEffect( () => {
-		if ( editor ) {
+		semaphore.runAfterMount( ( { instance } ) => {
 			if ( props.disabled ) {
-				editor.enableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
+				instance.enableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
 			} else {
-				editor.disableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
+				instance.disableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
 			}
-		}
+		} );
 	}, [ props.disabled ] );
-
-	useEffect( () => {
-		// When the component has been remounted, keeping the old state, it is important to avoid
-		// updating the editor, which will be destroyed by the unmount callback.
-		if ( editor && !editorDestructionInProgress.current ) {
-			const editorData = editor.getFullData();
-
-			setData( { ...editorData } );
-			setAttributes( { ...editor.getRootsAttributes() } );
-			setElements( [
-				...Object.keys( editorData ).map( rootName => _createEditableElement( editor, rootName ) )
-			] );
-		}
-	}, [ editor && editor.id ] );
 
 	/**
 	 * Returns the editor configuration.
@@ -108,7 +135,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 	/**
 	 * Callback function for handling changed data and attributes in the editor.
 	 */
-	const onChangeData = ( editor: MultiRootEditor, event: EventInfo ): void => {
+	const onChangeData = useRefSafeCallback( ( editor: MultiRootEditor, event: EventInfo ): void => {
 		const modelDocument = editor!.model.document;
 
 		if ( !props.disableTwoWayDataBinding ) {
@@ -167,15 +194,13 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 		if ( props.onChange ) {
 			props.onChange( event, editor! );
 		}
-	};
+	} );
 
 	/**
 	 * Callback function for handling an added root.
 	 */
-	const onAddRoot = ( editor: MultiRootEditor, evt: EventInfo, root: RootElement ): void => {
+	const onAddRoot = useRefSafeCallback( ( editor: MultiRootEditor, evt: EventInfo, root: RootElement ): void => {
 		const rootName = root.rootName;
-
-		const reactElement = _createEditableElement( editor, rootName );
 
 		if ( !props.disableTwoWayDataBinding ) {
 			setData( previousData =>
@@ -187,16 +212,14 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 			);
 		}
 
-		setElements( previousElements => [ ...previousElements, reactElement ] );
-	};
+		setRoots( prevRoots => uniq( [ ...prevRoots, root.rootName ] ) );
+	} );
 
 	/**
 	 * Callback function for handling a detached root.
 	 */
-	const onDetachRoot = ( editor: MultiRootEditor, evt: EventInfo, root: RootElement ): void => {
+	const onDetachRoot = useRefSafeCallback( ( editor: MultiRootEditor, evt: EventInfo, root: RootElement ): void => {
 		const rootName = root.rootName;
-
-		setElements( previousElements => previousElements.filter( element => element.props.id !== rootName ) );
 
 		if ( !props.disableTwoWayDataBinding ) {
 			setData( previousData => {
@@ -212,27 +235,8 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 			} );
 		}
 
-		editor!.detachEditable( root );
-	};
-
-	/**
-	 * Creates a React element on which the root editable element is initialized.
-	 */
-	const _createEditableElement = ( editor: MultiRootEditor, rootName: string ): JSX.Element => (
-		<div
-			id={rootName}
-			key={rootName}
-			ref={ el => {
-				if ( el ) {
-					const editable = editor.ui.view.createEditable( rootName, el );
-
-					editor.ui.addEditable( editable );
-
-					editor.editing.view.forceRender();
-				}
-			}}
-		></div>
-	);
+		setRoots( prevRoots => prevRoots.filter( root => root !== rootName ) );
+	} );
 
 	/**
 	 * Creates an editor using initial elements or data, and configuration.
@@ -240,18 +244,27 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 	 * @param initialData The initial data.
 	 * @param config CKEditor 5 editor configuration.
 	 */
-	const _createEditor = (
+	const _createEditor = useRefSafeCallback( (
 		initialData: Record<string, string> | Record<string, HTMLElement>,
 		config: EditorConfig
 	): Promise<MultiRootEditor> => {
+		overwriteObject( { ...props.rootsAttributes }, attributes );
+		overwriteObject( { ...props.data }, data );
+		overwriteArray( Object.keys( props.data ), roots );
+
 		return props.editor.create( initialData, config )
 			.then( ( editor: MultiRootEditor ) => {
+				const editorData = editor.getFullData();
+
+				// Rerender will be called anyway.
+				overwriteObject( { ...editorData }, data );
+				overwriteObject( { ...editor.getRootsAttributes() }, attributes );
+				overwriteArray( Object.keys( editorData ), roots );
+
 				if ( props.disabled ) {
 					// Switch to the read-only mode if the `[disabled]` attribute is specified.
 					/* istanbul ignore else */
-					if ( props.disabled ) {
-						editor.enableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
-					}
+					editor.enableReadOnlyMode( REACT_INTEGRATION_READ_ONLY_LOCK_ID );
 				}
 
 				const modelDocument = editor.model.document;
@@ -276,26 +289,17 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 					}
 				} );
 
-				setEditor( editor );
-
-				if ( props.onReady ) {
-					props.onReady( editor );
-				}
-
 				return editor;
 			} );
-	};
+	} );
 
 	/**
 	 * Destroys the editor by destroying the watchdog.
 	 */
-	const _destroyEditor = async (): Promise<void> => {
-		setEditor( null );
-		setData( {} );
-		setAttributes( {} );
-		setElements( [] );
+	const _destroyEditor = ( initializeResult: EditorSemaphoreMountResult<MultiRootEditor> ): Promise<void> => {
+		const { watchdog, instance } = initializeResult;
 
-		editorDestructionInProgress.current = new Promise<void>( resolve => {
+		return new Promise<void>( ( resolve, reject ) => {
 			// It may happen during the tests that the watchdog instance is not assigned before destroying itself. See: #197.
 			//
 			// Additionally, we need to find a way to detect if the whole context has been destroyed. As `componentWillUnmount()`
@@ -304,20 +308,22 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 			// the `ContextWatchdog#state` would have a correct value. See `EditorWatchdogAdapter#destroy()` for more information.
 			/* istanbul ignore next */
 			setTimeout( async () => {
-				if ( watchdog.current ) {
-					await watchdog.current.destroy();
-					watchdog.current = null;
+				try {
+					if ( watchdog ) {
+						await watchdog.destroy();
+						return resolve();
+					}
 
-					return resolve();
+					if ( instance ) {
+						await instance.destroy();
+						return resolve();
+					}
+
+					resolve();
+				} catch ( e ) {
+					console.error( e );
+					reject( e );
 				}
-
-				if ( editor ) {
-					await editor.destroy();
-
-					return resolve();
-				}
-
-				resolve();
 			} );
 		} );
 	};
@@ -325,94 +331,72 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 	/**
 	 * Initializes the editor by creating a proper watchdog and initializing it with the editor's configuration.
 	 */
-	const _initializeEditor = async (): Promise<void> => {
+	const _initializeEditor = async (): Promise<LifeCycleMountResult> => {
 		if ( props.disableWatchdog ) {
-			await _createEditor( props.data, _getConfig() );
+			const instance = await _createEditor( props.data as any, _getConfig() );
 
-			return;
+			return {
+				instance: instance as MultiRootEditor,
+				watchdog: null
+			};
 		}
 
-		/* istanbul ignore next */
-		if ( watchdog.current ) {
-			return;
-		}
+		const watchdog = ( () => {
+			if ( context instanceof ContextWatchdog ) {
+				return new EditorWatchdogAdapter( context );
+			}
 
-		if ( context instanceof ContextWatchdog ) {
-			watchdog.current = new EditorWatchdogAdapter( context );
-		} else {
-			watchdog.current = new EditorWatchdog( props.editor, props.watchdogConfig );
-		}
+			return new EditorWatchdog( props.editor, props.watchdogConfig );
+		} )() as EditorWatchdogAdapter<MultiRootEditor>;
 
-		const watchdogInstance = watchdog.current;
+		const totalRestartsRef = {
+			current: 0
+		};
 
-		watchdogInstance.setCreator( ( data, config ) => _createEditor( data as Record<string, string>, config ) );
+		watchdog.setCreator( async ( data, config ) => {
+			const { onAfterDestroy } = props;
 
-		watchdogInstance.on( 'error', ( _, { error, causesRestart } ) => {
+			if ( totalRestartsRef.current > 0 && onAfterDestroy && editorRefs.instance.current ) {
+				onAfterDestroy( editorRefs.instance.current );
+			}
+
+			const instance = await _createEditor( data as any, config );
+
+			if ( totalRestartsRef.current > 0 ) {
+				semaphore.unsafeSetValue( {
+					instance,
+					watchdog
+				} );
+
+				setTimeout( () => {
+					if ( props.onReady ) {
+						props.onReady( watchdog!.editor );
+					}
+				} );
+			}
+
+			totalRestartsRef.current++;
+			return instance;
+		} );
+
+		watchdog.on( 'error', ( _, { error, causesRestart } ) => {
 			const onError = props.onError || console.error;
-
 			onError( error, { phase: 'runtime', willEditorRestart: causesRestart } );
 		} );
 
-		await watchdogInstance
+		await watchdog
 			.create( data as any, _getConfig() )
 			.catch( error => {
 				const onError = props.onError || console.error;
-
 				onError( error, { phase: 'initialization', willEditorRestart: false } );
+				throw error;
 			} );
+
+		return {
+			watchdog,
+			instance: watchdog!.editor
+		};
 	};
-
-	useEffect( () => {
-		if ( !editor ) {
-			return;
-		}
-
-		// Editor should be only updated when the changes come from the integrator React application.
-		if ( shouldUpdateEditor.current ) {
-			shouldUpdateEditor.current = false;
-
-			const dataKeys = Object.keys( data );
-			const attributesKeys = Object.keys( attributes );
-
-			// Check if `data` and `attributes` have the same keys.
-			//
-			// It prevents the addition of attributes for non-existing roots.
-			// If the `data` object has a different set of keys, an error will not be thrown
-			// since the attributes will be removed/added during root initialization/destruction.
-			if ( !dataKeys.every( key => attributesKeys.includes( key ) ) ) {
-				throw new Error( '`data` and `attributes` objects must have the same keys (roots).' );
-			}
-
-			const editorData = editor.getFullData();
-			const editorAttributes = editor.getRootsAttributes();
-
-			const {
-				addedKeys: newRoots,
-				removedKeys: removedRoots
-			} = _getStateDiff( editorData, data || {} );
-
-			const hasModifiedData = dataKeys.some( rootName =>
-				editorData[ rootName ] !== undefined &&
-				JSON.stringify( editorData[ rootName ] ) !== JSON.stringify( data[ rootName ] )
-			);
-
-			const rootsWithChangedAttributes = attributesKeys.filter( rootName =>
-				JSON.stringify( editorAttributes[ rootName ] ) !== JSON.stringify( attributes[ rootName ] ) );
-
-			editor.model.change( writer => {
-				_handleNewRoots( newRoots );
-				_handleRemovedRoots( removedRoots );
-
-				if ( hasModifiedData ) {
-					_updateEditorData();
-				}
-
-				if ( rootsWithChangedAttributes.length ) {
-					_updateEditorAttributes( writer, rootsWithChangedAttributes );
-				}
-			} );
-		}
-	}, [ data, attributes ] );
 
 	const _getStateDiff = (
 		previousState: Record<string, unknown>,
@@ -430,64 +414,182 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 		};
 	};
 
-	const _handleNewRoots = ( roots: Array<string> ) => {
-		roots.forEach( rootName => {
-			editor!.addRoot( rootName, {
-				data: data[ rootName ] || '',
-				attributes: attributes?.[ rootName ] || {},
-				isUndoable: true
-			} );
-		} );
-	};
-
-	const _handleRemovedRoots = ( roots: Array<string> ) => {
-		roots.forEach( rootName => {
-			editor!.detachRoot( rootName, true );
-		} );
-	};
-
-	const _updateEditorData = () => {
-		// If any of the roots content has changed, set the editor data.
-		// Unfortunately, we cannot set the editor data just for one root, so we need to overwrite all roots (`nextProps.data` is an
-		// object with data for each root).
-		editor!.data.set( data, { suppressErrorInCollaboration: true } as any );
-	};
-
-	const _updateEditorAttributes = ( writer: Writer, roots: Array<string> ) => {
-		roots.forEach( rootName => {
-			Object.keys( attributes![ rootName ] ).forEach( attr => {
-				editor!.registerRootAttribute( attr );
-			} );
-
-			writer.clearAttributes( editor!.model.document.getRoot( rootName )! );
-			writer.setAttributes( attributes![ rootName ], editor!.model.document.getRoot( rootName )! );
-		} );
-	};
-
 	const _externalSetData: Dispatch<SetStateAction<Record<string, string>>> = useCallback(
 		newData => {
-			shouldUpdateEditor.current = true;
-			setData( newData );
+			semaphore.runAfterMount( () => {
+				shouldUpdateEditor.current = true;
+				setData( newData );
+			} );
 		},
 		[ setData ]
 	);
 
 	const _externalSetAttributes: Dispatch<SetStateAction<Record<string, Record<string, unknown>>>> = useCallback(
 		newAttributes => {
-			shouldUpdateEditor.current = true;
-			setAttributes( newAttributes );
+			semaphore.runAfterMount( () => {
+				shouldUpdateEditor.current = true;
+				setAttributes( newAttributes );
+			} );
 		},
 		[ setAttributes ]
 	);
 
+	const toolbarElement = (
+		<EditorToolbarWrapper
+			ref={ semaphoreElementRef }
+			editor={editorRefs.instance.current}
+		/>
+	);
+
+	useInstantEffect( () => {
+		semaphore.runAfterMount( ( { instance } ) => {
+			// Editor should be only updated when the changes come from the integrator React application.
+			if ( shouldUpdateEditor.current ) {
+				shouldUpdateEditor.current = false;
+
+				const dataKeys = Object.keys( data );
+				const attributesKeys = Object.keys( attributes );
+
+				// Check if `data` and `attributes` have the same keys.
+				//
+				// It prevents the addition of attributes for non-existing roots.
+				// If the `data` object has a different set of keys, an error will not be thrown
+				// since the attributes will be removed/added during root initialization/destruction.
+				if ( !dataKeys.every( key => attributesKeys.includes( key ) ) ) {
+					console.error( '`data` and `attributes` objects must have the same keys (roots).' );
+					throw new Error( '`data` and `attributes` objects must have the same keys (roots).' );
+				}
+
+				const editorData = instance.getFullData();
+				const editorAttributes = instance.getRootsAttributes();
+
+				const {
+					addedKeys: newRoots,
+					removedKeys: removedRoots
+				} = _getStateDiff( editorData, data || {} );
+
+				const hasModifiedData = dataKeys.some( rootName =>
+					editorData[ rootName ] !== undefined &&
+					JSON.stringify( editorData[ rootName ] ) !== JSON.stringify( data[ rootName ] )
+				);
+
+				const rootsWithChangedAttributes = attributesKeys.filter( rootName =>
+					JSON.stringify( editorAttributes[ rootName ] ) !== JSON.stringify( attributes[ rootName ] ) );
+
+				const _handleNewRoots = ( roots: Array<string> ) => {
+					roots.forEach( rootName => {
+						instance!.addRoot( rootName, {
+							data: data[ rootName ] || '',
+							attributes: attributes?.[ rootName ] || {},
+							isUndoable: true
+						} );
+					} );
+				};
+
+				const _handleRemovedRoots = ( roots: Array<string> ) => {
+					roots.forEach( rootName => {
+						instance!.detachRoot( rootName, true );
+					} );
+				};
+
+				const _updateEditorData = () => {
+					// If any of the roots content has changed, set the editor data.
+					// Unfortunately, we cannot set the editor data just for one root,
+					// so we need to overwrite all roots (`nextProps.data` is an
+					// object with data for each root).
+					instance.data.set( data, { suppressErrorInCollaboration: true } as any );
+				};
+
+				const _updateEditorAttributes = ( writer: Writer, roots: Array<string> ) => {
+					roots.forEach( rootName => {
+						Object.keys( attributes![ rootName ] ).forEach( attr => {
+							instance.registerRootAttribute( attr );
+						} );
+
+						writer.clearAttributes( instance.model.document.getRoot( rootName )! );
+						writer.setAttributes( attributes![ rootName ], instance.model.document.getRoot( rootName )! );
+					} );
+				};
+
+				// React struggles with rerendering during `instance.model.change` callbacks.
+				setTimeout( () => {
+					instance.model.change( writer => {
+						_handleNewRoots( newRoots );
+						_handleRemovedRoots( removedRoots );
+
+						if ( hasModifiedData ) {
+							_updateEditorData();
+						}
+
+						if ( rootsWithChangedAttributes.length ) {
+							_updateEditorAttributes( writer, rootsWithChangedAttributes );
+						}
+					} );
+				} );
+			}
+		} );
+	}, [ data, attributes ] );
+
+	const editableElements = roots.map(
+		rootName => (
+			<EditorEditable
+				key={rootName}
+				id={rootName}
+				rootName={rootName}
+				semaphore={semaphore}
+			/>
+		)
+	);
+
 	return {
-		editor, editableElements: elements, toolbarElement: <EditorToolbarWrapper editor={editor} />,
+		editor: editorRefs.instance.current,
+		editableElements,
+		toolbarElement,
 		data, setData: _externalSetData,
 		attributes, setAttributes: _externalSetAttributes
 	};
 };
 
-const EditorToolbarWrapper = ( { editor }: any ) => {
+const EditorEditable = memo( forwardRef( ( { id, semaphore, rootName }: {
+	id: string;
+	rootName: string;
+	semaphore: LifeCycleSemaphoreSyncRefResult<LifeCycleMountResult>;
+}, ref ) => {
+	const innerRef = useRef<HTMLDivElement>( null );
+
+	useEffect( () => {
+		let editable: InlineEditableUIView | null;
+		let editor: MultiRootEditor | null;
+
+		semaphore.runAfterMount( ( { instance } ) => {
+			if ( innerRef.current ) {
+				editor = instance;
+				editable = instance.ui.view.createEditable( rootName, innerRef.current );
+
+				instance.ui.addEditable( editable );
+				instance.editing.view.forceRender();
+			}
+		} );
+
+		return () => {
+			if ( editable && innerRef.current && editor && editor.state !== 'destroyed' ) {
+				editor.ui.removeEditable( editable );
+			}
+		};
+	}, [ semaphore.revision ] );
+
+	return (
+		<div
+			key={semaphore.revision}
+			id={id}
+			ref={ mergeRefs( ref, innerRef ) }
+		/>
+	);
+} ) );
+
+EditorEditable.displayName = 'EditorEditable';
+
+const EditorToolbarWrapper = forwardRef( ( { editor }: any, ref ) => {
 	const toolbarRef = useRef<HTMLDivElement>( null );
 
 	useEffect( () => {
@@ -510,10 +612,18 @@ const EditorToolbarWrapper = ( { editor }: any ) => {
 		};
 	}, [ editor && editor.id ] );
 
-	return <div ref={toolbarRef}></div>;
-};
+	return <div ref={mergeRefs( toolbarRef, ref )}></div>;
+} );
+
+EditorToolbarWrapper.displayName = 'EditorToolbarWrapper';
 
 export default useMultiRootEditor;
+
+type LifeCycleMountResult = EditorSemaphoreMountResult<MultiRootEditor>;
+
+type LifeCycleSemaphoreRefs<TEditor extends MultiRootEditor> = {
+	[ K in keyof EditorSemaphoreMountResult<TEditor> ]: RefObject<EditorSemaphoreMountResult<TEditor>[ K ]>
+};
 
 interface ErrorDetails {
 	phase: 'initialization' | 'runtime';
@@ -521,6 +631,9 @@ interface ErrorDetails {
 }
 
 export type MultiRootHookProps = {
+	id?: any;
+	semaphoreElement?: HTMLElement;
+
 	isLayoutReady?: boolean;
 	disabled?: boolean;
 	data: Record<string, string>;
@@ -531,6 +644,7 @@ export type MultiRootHookProps = {
 	disableTwoWayDataBinding?: boolean;
 
 	onReady?: ( editor: MultiRootEditor ) => void;
+	onAfterDestroy?: ( editor: MultiRootEditor ) => void;
 	onError?: ( error: Error, details: ErrorDetails ) => void;
 	onChange?: ( event: EventInfo, editor: MultiRootEditor ) => void;
 	onFocus?: ( event: EventInfo, editor: MultiRootEditor ) => void;

--- a/src/utils/defer.ts
+++ b/src/utils/defer.ts
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export type Defer<E> = {
+	promise: Promise<E>;
+	resolve: ( value: E ) => void;
+};
+
+/**
+ * This function generates a promise that can be resolved by invoking the returned `resolve` method.
+ * It proves to be beneficial in the creation of various types of locks and semaphores.
+ */
+export function createDefer<E = void>(): Defer<E> {
+	const deferred: Defer<E> = {
+		resolve: null as any,
+		promise: null as any
+	};
+
+	deferred.promise = new Promise<E>( resolve => {
+		deferred.resolve = resolve;
+	} );
+
+	return deferred;
+}

--- a/src/utils/mergeRefs.ts
+++ b/src/utils/mergeRefs.ts
@@ -1,0 +1,25 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { MutableRefObject } from 'react';
+
+type CallbackRef<T> = ( element: T ) => void;
+
+type ReactRef<T> = CallbackRef<T | null> | MutableRefObject<T | null> | null;
+
+/**
+ * Combine multiple react refs into one.
+ */
+export function mergeRefs<T>( ...refs: Array<ReactRef<T>> ): CallbackRef<T> {
+	return value => {
+		refs.forEach( ref => {
+			if ( typeof ref === 'function' ) {
+				ref( value );
+			} else if ( ref != null ) {
+				ref.current = value;
+			}
+		} );
+	};
+}

--- a/src/utils/once.ts
+++ b/src/utils/once.ts
@@ -1,0 +1,21 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Ensures that passed function will be executed only once.
+ */
+export function once<A extends Array<any>, R = void>( fn: ( ...args: A ) => R ): ( ...args: A ) => R {
+	let lastResult: { current: R } | null = null;
+
+	return ( ...args: A ): R => {
+		if ( !lastResult ) {
+			lastResult = {
+				current: fn( ...args )
+			};
+		}
+
+		return lastResult.current;
+	};
+}

--- a/src/utils/overwriteArray.ts
+++ b/src/utils/overwriteArray.ts
@@ -1,0 +1,14 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Clear whole array while keeping its reference.
+ */
+export function overwriteArray<A extends Array<any>>( source: A, destination: A ): A {
+	destination.length = 0;
+	destination.push( ...source );
+
+	return destination;
+}

--- a/src/utils/overwriteObject.ts
+++ b/src/utils/overwriteObject.ts
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Clears whole object while keeping its reference.
+ */
+export function overwriteObject<O extends Record<string, any>>( source: O, destination: O ): O {
+	for ( const prop of Object.getOwnPropertyNames( destination ) ) {
+		delete destination[ prop ];
+	}
+
+	// Prevent assigning self referencing attributes which crashes `Object.assign`.
+	for ( const [ key, value ] of Object.entries( source ) ) {
+		if ( value !== destination && key !== 'prototype' && key !== '__proto__' ) {
+			( destination as any )[ key ] = value;
+		}
+	}
+
+	return destination;
+}

--- a/src/utils/shallowCompareArrays.ts
+++ b/src/utils/shallowCompareArrays.ts
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * Shallow comparison of two arrays.
+ */
+export const shallowCompareArrays = <T>(
+	a: Readonly<Array<T>>,
+	b: Readonly<Array<T>>
+): boolean => {
+	if ( a === b ) {
+		return true;
+	}
+
+	if ( !a || !b ) {
+		return false;
+	}
+
+	for ( let i = 0; i < a.length; ++i ) {
+		if ( a[ i ] !== b[ i ] ) {
+			return false;
+		}
+	}
+
+	return true;
+};

--- a/src/utils/uniq.ts
+++ b/src/utils/uniq.ts
@@ -1,0 +1,11 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * A utility function that removes duplicate elements from an array.
+ */
+export function uniq<A>( source: Array<A> ): Array<A> {
+	return Array.from( new Set( source ) );
+}

--- a/tests/_utils/defer.js
+++ b/tests/_utils/defer.js
@@ -1,0 +1,17 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export function createDefer() {
+	const deferred = {
+		resolve: ( ) => {},
+		promise: Promise.resolve( null )
+	};
+
+	deferred.promise = new Promise( resolve => {
+		deferred.resolve = resolve;
+	} );
+
+	return deferred;
+}

--- a/tests/_utils/editor.js
+++ b/tests/_utils/editor.js
@@ -11,7 +11,10 @@
  * @see: https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editor-Editor.html
  */
 export default class Editor {
-	constructor() {
+	constructor( element, config ) {
+		this.element = element;
+		this.config = config;
+
 		this.initializeProperties();
 	}
 
@@ -70,8 +73,8 @@ export default class Editor {
 		return this.data.get.call( this, ...args );
 	}
 
-	static create() {
-		return Promise.resolve( new this() );
+	static create( element, config ) {
+		return Promise.resolve( new this( element, config ) );
 	}
 }
 

--- a/tests/_utils/timeout.js
+++ b/tests/_utils/timeout.js
@@ -1,0 +1,10 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export function timeout( ms ) {
+	return new Promise( resolve => {
+		setTimeout( resolve, ms );
+	} );
+}

--- a/tests/_utils/waitFor.js
+++ b/tests/_utils/waitFor.js
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export async function waitFor( callback, { timeOut = 1000, retry = 50 } = {} ) {
+	return new Promise( ( resolve, reject ) => {
+		const startTime = Date.now();
+
+		const tick = () => {
+			setTimeout( async () => {
+				try {
+					resolve( await callback() );
+				} catch ( err ) {
+					if ( Date.now() - startTime > timeOut ) {
+						reject( err );
+					} else {
+						tick();
+					}
+				}
+			}, retry );
+		};
+
+		tick();
+	} );
+}

--- a/tests/ckeditorcontext.jsx
+++ b/tests/ckeditorcontext.jsx
@@ -13,6 +13,7 @@ import ContextWatchdog from '@ckeditor/ckeditor5-watchdog/src/contextwatchdog';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import turnOffDefaultErrorCatching from './_utils/turnoffdefaulterrorcatching.js';
 import ContextMock from './_utils/context.js';
+import { waitFor } from './_utils/waitFor.js';
 
 configure( { adapter: new Adapter() } );
 
@@ -118,11 +119,13 @@ describe( '<CKEditorContext> Component', () => {
 				} );
 			} );
 
-			const editor1 = wrapper.childAt( 0 ).instance().editor;
-			const editor2 = wrapper.childAt( 1 ).instance().editor;
+			await waitFor( () => {
+				const editor1 = wrapper.childAt( 0 ).instance().editor;
+				const editor2 = wrapper.childAt( 1 ).instance().editor;
 
-			expect( editor1 ).to.be.an( 'object' );
-			expect( editor2 ).to.be.an( 'object' );
+				expect( editor1 ).to.be.an( 'object' );
+				expect( editor2 ).to.be.an( 'object' );
+			} );
 
 			sinon.assert.calledTwice( editorCreateSpy );
 
@@ -321,10 +324,12 @@ describe( '<CKEditorContext> Component', () => {
 				} );
 			} );
 
-			const { watchdog: secondWatchdog } = wrapper.childAt( 0 ).instance();
+			await waitFor( () => {
+				const { watchdog: secondWatchdog } = wrapper.childAt( 0 ).instance();
 
-			expect( secondWatchdog ).to.not.equal( null );
-			expect( secondWatchdog._contextWatchdog.state ).to.equal( 'ready' );
+				expect( secondWatchdog ).to.not.equal( null );
+				expect( secondWatchdog._contextWatchdog.state ).to.equal( 'ready' );
+			} );
 		} );
 
 		it( 'should not re-render the component if layout is not ready after initialization', async () => {

--- a/tests/integrations/ckeditor-classiceditor.jsx
+++ b/tests/integrations/ckeditor-classiceditor.jsx
@@ -11,6 +11,7 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import CKEditor from '../../src/ckeditor.tsx';
+import { timeout } from '../_utils/timeout.js';
 
 configure( { adapter: new Adapter() } );
 
@@ -130,7 +131,12 @@ describe( '<CKEditor> memory usage', () => {
 		function createAndDestroy() {
 			return Promise.resolve()
 				.then( createEditor )
-				.then( destroyEditor );
+				.then( destroyEditor )
+				.then( () => {
+					// Simulate real world rerendering queue. Unmounting of editor is *async* so it'll take a while
+					// to unmount existing instance of editor.
+					return timeout( 200 );
+				} );
 		}
 	}
 

--- a/tests/issues/354-destroy-editor-inside-context.jsx
+++ b/tests/issues/354-destroy-editor-inside-context.jsx
@@ -10,6 +10,7 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import CKEditor from '../../src/ckeditor.tsx';
 import CKEditorContext from '../../src/ckeditorcontext.tsx';
+import { waitFor } from '../_utils/waitFor.js';
 
 const { Context } = window.CKEditor5.core;
 
@@ -75,15 +76,9 @@ describe( 'issue #354: unable to destroy the editor within a context', () => {
 	it( 'should destroy the editor within a context', async () => {
 		wrapper.find( App ).setState( { renderEditor: false } );
 
-		await wait( 0 );
-
-		expect( wrapper.find( CKEditor ).exists() ).to.equal( false );
-		expect( wrapper.find( App ).getDOMNode().querySelector( '.ck-editor' ) ).to.equal( null );
+		await waitFor( () => {
+			expect( wrapper.find( CKEditor ).exists() ).to.equal( false );
+			expect( wrapper.find( App ).getDOMNode().querySelector( '.ck-editor' ) ).to.equal( null );
+		} );
 	} );
 } );
-
-function wait( ms ) {
-	return new Promise( resolve => {
-		setTimeout( resolve, ms );
-	} );
-}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add CKEditor component initialize / destroy semaphore to prevent race conditions during fast rerender. Closes https://github.com/ckeditor/ckeditor5-react/issues/442, https://github.com/ckeditor/ckeditor5-react/issues/469, https://github.com/ckeditor/ckeditor5-react/issues/471, https://github.com/ckeditor/ckeditor5-react/issues/476.

---

### Additional information

Probably related to these issues: 
https://github.com/ckeditor/ckeditor5-react/issues/469
https://github.com/ckeditor/ckeditor5-react/issues/409
https://github.com/ckeditor/ckeditor5/issues/15980
https://github.com/ckeditor/ckeditor5-react/issues/442
https://github.com/ckeditor/ckeditor5-react/issues/476
