### PR TITLE
Restore 100% coverage in project after migration to vitest. 

### DIFF
--- a/src/ckeditorcontext.tsx
+++ b/src/ckeditorcontext.tsx
@@ -100,6 +100,7 @@ const CKEditorContext = <TContext extends Context = Context>( props: Props<TCont
 
 		// Handle error event from context watchdog.
 		contextWatchdog.on( 'error', ( _, errorEvent ) => {
+			// istanbul ignore else
 			if ( canUpdateState( watchdogInitializationID ) ) {
 				onError( errorEvent.error, {
 					phase: 'runtime',

--- a/src/hooks/useInstantEditorEffect.ts
+++ b/src/hooks/useInstantEditorEffect.ts
@@ -11,7 +11,7 @@ import { useInstantEffect } from './useInstantEffect';
  * `useEffect` alternative but executed after mounting of editor.
  */
 export const useInstantEditorEffect = <R>(
-	semaphore: LifeCycleElementSemaphore<R> | null,
+	semaphore: Pick<LifeCycleElementSemaphore<R>, 'runAfterMount'> | null,
 	fn: ( mountResult: R ) => void,
 	deps: DependencyList
 ): void => {

--- a/src/lifecycle/LifeCycleElementSemaphore.ts
+++ b/src/lifecycle/LifeCycleElementSemaphore.ts
@@ -287,7 +287,7 @@ type LifeCyclePostMountAttrs<R> = {
 	mountResult: R;
 };
 
-type LifeCycleAsyncOperators<R> = {
+export type LifeCycleAsyncOperators<R> = {
 	mount: () => Promise<R>;
 	afterMount?: ( result: LifeCyclePostMountAttrs<R> ) => Promise<void> | void;
 	unmount: ( result: LifeCyclePostMountAttrs<R> ) => Promise<void>;

--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -499,7 +499,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 			const {
 				addedKeys: newRoots,
 				removedKeys: removedRoots
-			} = _getStateDiff( editorData, data );
+			} = _getStateDiff( editorData, data || /* istanbul ignore next: It should never happen, data should be always filled. */ {} );
 
 			const hasModifiedData = dataKeys.some( rootName =>
 				editorData[ rootName ] !== undefined &&
@@ -513,7 +513,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 				roots.forEach( rootName => {
 					instance!.addRoot( rootName, {
 						data: data[ rootName ] || '',
-						attributes: attributes?.[ rootName ],
+						attributes: attributes?.[ rootName ] || /* istanbul ignore next: attributes should be in sync with root keys */ {},
 						isUndoable: true
 					} );
 				} );

--- a/tests/_utils/multirooteditor.ts
+++ b/tests/_utils/multirooteditor.ts
@@ -25,10 +25,17 @@ import {
 	PasteFromOffice,
 	Table,
 	TableToolbar,
-	TextTransformation
+	TextTransformation,
+	type ContextWatchdog
 } from 'ckeditor5';
 
 export class TestMultiRootEditor extends MultiRootEditor {}
+
+export const createTestMultiRootWatchdog = async (): Promise<ContextWatchdog> => {
+	const contextWatchdog = new TestMultiRootEditor.ContextWatchdog( TestMultiRootEditor.Context );
+	await contextWatchdog.create();
+	return contextWatchdog;
+};
 
 TestMultiRootEditor.builtinPlugins = [
 	Essentials,

--- a/tests/ckeditor.test.tsx
+++ b/tests/ckeditor.test.tsx
@@ -1040,11 +1040,14 @@ describe( '<CKEditor> Component', () => {
 
 	describe( 'in case of error handling', () => {
 		it( 'should restart the editor if a runtime error occurs', async () => {
+			const onAfterDestroySpy = vi.fn();
+
 			component = render(
 				<CKEditor
 					ref={instanceRef}
 					editor={MockEditor}
 					onReady={manager.resolveOnRun()}
+					onAfterDestroy={onAfterDestroySpy}
 				/>
 			);
 
@@ -1061,6 +1064,7 @@ describe( '<CKEditor> Component', () => {
 							ref={instanceRef}
 							editor={MockEditor}
 							onReady={res}
+							onAfterDestroy={onAfterDestroySpy}
 						/>
 					);
 
@@ -1075,6 +1079,7 @@ describe( '<CKEditor> Component', () => {
 
 				expect( editor ).to.be.instanceOf( MockEditor );
 				expect( firstEditor ).to.not.equal( editor );
+				expect( onAfterDestroySpy ).toHaveBeenCalledOnce();
 			} );
 		} );
 	} );

--- a/tests/hooks/useInstantEditorEffect.test.tsx
+++ b/tests/hooks/useInstantEditorEffect.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useInstantEditorEffect } from '../../src/hooks/useInstantEditorEffect';
+
+describe( 'useInstantEditorEffect', () => {
+	it( 'should execute the provided function after mounting of editor', () => {
+		const semaphore = {
+			runAfterMount: vi.fn()
+		};
+
+		const fn = vi.fn();
+
+		renderHook( () => useInstantEditorEffect( semaphore, fn, [] ) );
+		expect( semaphore.runAfterMount ).toHaveBeenCalledWith( fn );
+	} );
+
+	it( 'should not execute the provided function if semaphore is null', () => {
+		const semaphore = null;
+
+		const fn = vi.fn();
+
+		renderHook( () => useInstantEditorEffect( semaphore, fn, [] ) );
+
+		expect( fn ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should re-execute the provided function when the dependencies change', () => {
+		const semaphore = {
+			runAfterMount: vi.fn()
+		};
+
+		const fn = vi.fn();
+
+		const { rerender } = renderHook( ( { semaphore, fn } ) => useInstantEditorEffect( semaphore, fn, [ semaphore ] ), {
+			initialProps: { semaphore, fn }
+		} );
+
+		expect( semaphore.runAfterMount ).toHaveBeenCalledOnce();
+
+		const newSemaphore = {
+			runAfterMount: vi.fn()
+		};
+
+		rerender( {
+			semaphore: newSemaphore,
+			fn
+		} );
+
+		expect( semaphore.runAfterMount ).toHaveBeenCalledOnce();
+		expect( newSemaphore.runAfterMount ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'should not re-execute the provided function when the dependencies do not change', () => {
+		const semaphore = {
+			runAfterMount: vi.fn()
+		};
+
+		const fn = vi.fn();
+
+		const { rerender } = renderHook( ( { semaphore, fn } ) => useInstantEditorEffect( semaphore, fn, [ semaphore ] ), {
+			initialProps: { semaphore, fn }
+		} );
+
+		expect( semaphore.runAfterMount ).toHaveBeenCalledOnce();
+
+		rerender( {
+			semaphore,
+			fn
+		} );
+
+		expect( semaphore.runAfterMount ).toHaveBeenCalledOnce();
+	} );
+} );

--- a/tests/hooks/useInstantEffect.test.tsx
+++ b/tests/hooks/useInstantEffect.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useInstantEffect } from '../../src/hooks/useInstantEffect';
+
+describe( 'useInstantEffect', () => {
+	it( 'should call the effect function when dependencies change', () => {
+		const effectFn = vi.fn();
+		const { rerender } = renderHook( deps => useInstantEffect( effectFn, deps ), {
+			initialProps: [ 1, 2, 3 ]
+		} );
+
+		expect( effectFn ).toHaveBeenCalledTimes( 1 );
+
+		rerender( [ 4, 5, 6 ] );
+		expect( effectFn ).toHaveBeenCalledTimes( 2 );
+
+		rerender( [ 4, 5, 6 ] );
+		expect( effectFn ).toHaveBeenCalledTimes( 2 );
+
+		rerender( [ 7, 8, 9 ] );
+		expect( effectFn ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'should not call the effect function when dependencies do not change', () => {
+		const effectFn = vi.fn();
+		const { rerender } = renderHook( deps => useInstantEffect( effectFn, deps ), {
+			initialProps: [ 1, 2, 3 ]
+		} );
+
+		expect( effectFn ).toHaveBeenCalledTimes( 1 );
+
+		rerender( [ 1, 2, 3 ] );
+		expect( effectFn ).toHaveBeenCalledTimes( 1 );
+
+		rerender( [ 1, 2, 3 ] );
+		expect( effectFn ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/tests/hooks/useIsMountedRef.test.tsx
+++ b/tests/hooks/useIsMountedRef.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { useIsMountedRef } from '../../src/hooks/useIsMountedRef';
+
+describe( 'useIsMountedRef', () => {
+	it( 'should return a mutable ref object', () => {
+		const { result } = renderHook( () => useIsMountedRef() );
+
+		expect( result.current.current ).to.be.true;
+	} );
+
+	it( 'should update the ref object when the component is unmounted', () => {
+		const { result, unmount } = renderHook( () => useIsMountedRef() );
+
+		expect( result.current.current ).to.be.true;
+
+		unmount();
+
+		expect( result.current.current ).to.be.false;
+	} );
+} );

--- a/tests/hooks/useRefSafeCallback.test.tsx
+++ b/tests/hooks/useRefSafeCallback.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { expect, it, describe, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react-hooks/dom';
+import { useRefSafeCallback } from '../../src/hooks/useRefSafeCallback';
+
+describe( 'useRefSafeCallback', () => {
+	it( 'should return a function', () => {
+		const { result } = renderHook( () => useRefSafeCallback( () => {} ) );
+
+		expect( typeof result.current ).toBe( 'function' );
+	} );
+
+	it( 'should return the same function reference', () => {
+		const { result, rerender } = renderHook( callback => useRefSafeCallback( callback ), {
+			initialProps: () => {}
+		} );
+
+		const initialCallback = result.current;
+		const newFnSpy = vi.fn();
+
+		rerender( newFnSpy );
+
+		expect( result.current ).toBe( initialCallback );
+		expect( newFnSpy ).not.toHaveBeenCalled();
+
+		result.current();
+		expect( newFnSpy ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'should call the callback with the provided arguments', () => {
+		const callback = vi.fn();
+		const { result } = renderHook( () => useRefSafeCallback( callback ) );
+
+		act( () => {
+			result.current( 'arg1', 'arg2' );
+		} );
+
+		expect( callback ).toHaveBeenCalledWith( 'arg1', 'arg2' );
+	} );
+
+	it( 'should return the result of the callback', () => {
+		const { result } = renderHook( () => useRefSafeCallback( () => 'result' ) );
+
+		const callbackResult = result.current();
+
+		expect( callbackResult ).toBe( 'result' );
+	} );
+} );

--- a/tests/lifecycle/LifeCycleElementSemaphore.test.tsx
+++ b/tests/lifecycle/LifeCycleElementSemaphore.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createDefer } from '../_utils/defer';
+import {
+	LifeCycleElementSemaphore,
+	type LifeCycleAsyncOperators
+} from '../../src/lifecycle/LifeCycleElementSemaphore';
+
+describe( 'LifeCycleElementSemaphore', () => {
+	let element: HTMLElement;
+	let lifecycle: LifeCycleAsyncOperators<any>;
+	let semaphore: LifeCycleElementSemaphore<any>;
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		lifecycle = {
+			mount: async () => {},
+			unmount: async () => {}
+		};
+
+		semaphore = new LifeCycleElementSemaphore( element, lifecycle );
+	} );
+
+	afterEach( () => {
+		semaphore.release();
+		vi.restoreAllMocks();
+		vi.clearAllTimers();
+	} );
+
+	it( 'should initialize with correct values', () => {
+		expect( semaphore.value ).toBeNull();
+	} );
+
+	it( 'should set value correctly', () => {
+		const value = {};
+
+		semaphore.unsafeSetValue( value );
+
+		expect( semaphore.value ).toBe( value );
+	} );
+
+	it( 'should run after mount callback immediately if value is already set', () => {
+		const value = {};
+		const callback = vi.fn();
+
+		semaphore.unsafeSetValue( value );
+		semaphore.runAfterMount( callback );
+
+		expect( callback ).toHaveBeenCalledWith( value );
+	} );
+
+	it( 'should run after mount callback after mount', async () => {
+		const value = {};
+		const callback = vi.fn();
+
+		semaphore.runAfterMount( callback );
+		semaphore.unsafeSetValue( value );
+
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( callback ).toHaveBeenCalledWith( value );
+	} );
+
+	it( 'should not run after mount callback if value is not set', () => {
+		const callback = vi.fn();
+
+		semaphore.runAfterMount( callback );
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should wait for previous semaphore to be resolved on element to start mounting new one', async () => {
+		const sharedElement = document.createElement( 'div' );
+		const firstMountDefer = createDefer();
+
+		const firstLifeCycle: LifeCycleAsyncOperators<any> = {
+			mount: async () => {
+				await firstMountDefer.promise;
+				return 'mounted';
+			},
+			unmount: vi.fn( async () => {} )
+		};
+
+		const secondLifeCycle: LifeCycleAsyncOperators<any> = {
+			mount: vi.fn( async () => {} ),
+			unmount: vi.fn( async () => {} )
+		};
+
+		const firstSemaphore = new LifeCycleElementSemaphore( sharedElement, firstLifeCycle );
+
+		// eslint-disable-next-line no-new
+		new LifeCycleElementSemaphore( sharedElement, secondLifeCycle );
+
+		// It may be not needed but it's better to wait for the next tick to ensure that the first semaphore is waiting
+		// for the defer to be resolved.
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		// It's still mounting at this stage.
+		expect( firstLifeCycle.unmount ).not.toBeCalled();
+		expect( secondLifeCycle.mount ).not.toBeCalled();
+
+		// Resolve the first semaphore, first semaphore is mounted.
+		firstMountDefer.resolve();
+
+		await vi.waitFor( () => {
+			expect( firstSemaphore.value ).toBe( 'mounted' );
+		} );
+
+		firstSemaphore.release();
+
+		// Second semaphore can be now mounted.
+		await vi.waitFor( async () => {
+			expect( firstLifeCycle.unmount ).toBeCalled();
+			expect( secondLifeCycle.mount ).toBeCalled();
+		} );
+	} );
+
+	it( 'should not call lifecycle methods of the second semaphore when three are mounted in the row', async () => {
+		const sharedElement = document.createElement( 'div' );
+		const firstMountDefer = createDefer();
+
+		const firstLifeCycle: LifeCycleAsyncOperators<any> = {
+			mount: async () => {
+				await firstMountDefer.promise;
+				return 'mounted';
+			},
+			unmount: vi.fn( async () => {} )
+		};
+
+		const secondLifeCycle: LifeCycleAsyncOperators<any> = {
+			mount: vi.fn( async () => {} ),
+			unmount: vi.fn( async () => {} )
+		};
+
+		const thirdLifeCycle: LifeCycleAsyncOperators<any> = {
+			mount: vi.fn( async () => {} ),
+			unmount: vi.fn( async () => {} )
+		};
+
+		// In this scenario it should trigger `mount` and `unmount` lifecycle methods of the first semaphore
+		// and the last one. The second semaphore should be skipped because it has been released before
+		// fully initialization of first semaphore.
+		const firstSemaphore = new LifeCycleElementSemaphore( sharedElement, firstLifeCycle );
+
+		// This one should be skipped.
+		const secondSemaphore = new LifeCycleElementSemaphore( sharedElement, secondLifeCycle );
+		secondSemaphore.release();
+
+		// eslint-disable-next-line no-new
+		new LifeCycleElementSemaphore( sharedElement, thirdLifeCycle );
+
+		// Resolve the first semaphore, first semaphore is mounted
+		firstMountDefer.resolve();
+
+		await vi.waitFor( () => {
+			expect( firstSemaphore.value ).toBe( 'mounted' );
+		} );
+
+		firstSemaphore.release();
+
+		// Second semaphore should be skipped and third one should be initialized instead.
+		await vi.waitFor( async () => {
+			expect( firstLifeCycle.unmount ).toBeCalled();
+
+			// Skipped semaphore.
+			expect( secondLifeCycle.mount ).not.toBeCalled();
+			expect( secondLifeCycle.unmount ).not.toBeCalled();
+
+			// Initialized semaphore.
+			expect( thirdLifeCycle.mount ).toBeCalled();
+		} );
+	} );
+
+	it( 'should log console error when semaphore thrown exception during unmount', async () => {
+		const error = new Error( 'Unmount error' );
+		const semaphore = new LifeCycleElementSemaphore( document.createElement( 'div' ), {
+			mount: async () => 'mounted',
+			unmount: async () => {
+				throw error;
+			}
+		} );
+
+		const consoleError = vi.spyOn( console, 'error' );
+
+		await vi.waitFor( () => {
+			expect( semaphore.value ).toBe( 'mounted' );
+		} );
+
+		semaphore.release();
+
+		await vi.waitFor( () => {
+			expect( consoleError ).toBeCalledWith( 'Semaphore unmounting error:', error );
+		} );
+	} );
+
+	it( 'should log console error when semaphore thrown exception during mount', async () => {
+		const error = new Error( 'Unmount error' );
+		const consoleError = vi.spyOn( console, 'error' );
+
+		// eslint-disable-next-line no-new
+		new LifeCycleElementSemaphore( document.createElement( 'div' ), {
+			mount: async () => {
+				throw error;
+			},
+			unmount: async () => {}
+		} );
+
+		await vi.waitFor( () => {
+			expect( consoleError ).toBeCalledWith( 'Semaphore mounting error:', error );
+		} );
+	} );
+
+	it( 'should not call `afterMount` lifecycle method if there is no mount result', async () => {
+		const defer = createDefer();
+		const runAfterMount = vi.fn();
+
+		// eslint-disable-next-line no-new
+		new LifeCycleElementSemaphore( document.createElement( 'div' ), {
+			mount: async () => {
+				await defer.promise;
+			},
+			unmount: async () => {},
+			afterMount: runAfterMount
+		} );
+
+		expect( runAfterMount ).not.toBeCalled();
+		defer.resolve();
+
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( runAfterMount ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should call `afterMount` lifecycle method if there is mount result', async () => {
+		const defer = createDefer();
+		const runAfterMount = vi.fn();
+
+		// eslint-disable-next-line no-new
+		new LifeCycleElementSemaphore( document.createElement( 'div' ), {
+			mount: async () => {
+				await defer.promise;
+				return 'mounted';
+			},
+			unmount: async () => {},
+			afterMount: runAfterMount
+		} );
+
+		expect( runAfterMount ).not.toBeCalled();
+		defer.resolve();
+
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( runAfterMount ).toHaveBeenCalledWith( {
+			element: expect.any( HTMLElement ),
+			mountResult: 'mounted'
+		} );
+	} );
+
+	it( 'should release semaphore', () => {
+		semaphore.release();
+		expect( semaphore.value ).toBeNull();
+	} );
+} );

--- a/tests/lifecycle/useLifeCycleSemaphoreSyncRef.test.tsx
+++ b/tests/lifecycle/useLifeCycleSemaphoreSyncRef.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { it, describe, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react-hooks/dom';
+
+import { LifeCycleElementSemaphore } from '../../src/lifecycle/LifeCycleElementSemaphore';
+import { useLifeCycleSemaphoreSyncRef } from '../../src/lifecycle/useLifeCycleSemaphoreSyncRef';
+
+describe( 'useLifeCycleSemaphoreSyncRef', () => {
+	let semaphore: LifeCycleElementSemaphore<any>;
+
+	beforeEach( () => {
+		semaphore = new LifeCycleElementSemaphore<any>( document.createElement( 'div' ), {
+			mount: async () => {},
+			unmount: async () => {}
+		} );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.clearAllTimers();
+	} );
+
+	it( 'should initialize with null semaphore', () => {
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef() );
+
+		expect( result.current.current ).toBeNull();
+	} );
+
+	it( 'should create attribute ref with null value if semaphore is not assigned', () => {
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef<{ key: string }>() );
+		const attributeRef = result.current.createAttributeRef( 'key' );
+
+		expect( attributeRef.current ).toBeNull();
+	} );
+
+	it( 'should set proper value and refresh if semaphore is assigned', () => {
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef<{ key: string }>() );
+
+		act( () => {
+			result.current.replace( () => semaphore );
+			result.current.unsafeSetValue( { key: 'value' } );
+		} );
+
+		expect( result.current.current?.value ).toEqual( { key: 'value' } );
+		expect( result.current.revision ).not.toBeNaN();
+	} );
+
+	it( 'should not execute callback passed to `runAfterMount` if semaphore didn\'t resolve anything', async () => {
+		const runAfterMountSpy = vi.fn();
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef() );
+
+		act( () => {
+			result.current.replace( () => semaphore );
+			result.current.runAfterMount( runAfterMountSpy );
+		} );
+
+		await new Promise( resolve => setTimeout( resolve, 30 ) );
+
+		expect( runAfterMountSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should execute callback passed to `runAfterMount` if semaphore resolved value', async () => {
+		const runAfterMountSpy = vi.fn();
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef<{ key: string }>() );
+
+		act( () => {
+			result.current.replace( () => semaphore );
+			result.current.unsafeSetValue( { key: 'value' } );
+			result.current.runAfterMount( runAfterMountSpy );
+		} );
+
+		await new Promise( resolve => setTimeout( resolve, 30 ) );
+
+		expect( runAfterMountSpy ).toHaveBeenCalledWith( { key: 'value' } );
+	} );
+
+	it( 'should reset semaphore and refresh when `release` is called', async () => {
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef<{ key: string }>() );
+
+		act( () => {
+			result.current.replace( () => semaphore );
+			result.current.unsafeSetValue( { key: 'value' } );
+		} );
+
+		const currentRevision = result.current.revision;
+
+		await new Promise( resolve => setTimeout( resolve, 30 ) );
+
+		act( () => {
+			result.current.release();
+		} );
+
+		expect( result.current.current ).toBeNull();
+		expect( result.current.revision ).to.be.greaterThan( currentRevision );
+	} );
+
+	it( 'should create new revision if semaphore is replaced', async () => {
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef<{ key: string }>() );
+		const currentRevision = result.current.revision;
+
+		await new Promise( resolve => setTimeout( resolve, 30 ) );
+
+		act( () => {
+			result.current.replace( () => semaphore );
+		} );
+
+		expect( result.current.revision ).to.be.greaterThan( currentRevision );
+	} );
+
+	it( 'should bind semaphore values to attribute refs', () => {
+		const { result } = renderHook( () => useLifeCycleSemaphoreSyncRef<{ key: string }>() );
+		const attributeRef = result.current.createAttributeRef( 'key' );
+
+		expect( attributeRef.current ).toBeNull();
+
+		act( () => {
+			result.current.replace( () => semaphore );
+			result.current.unsafeSetValue( { key: 'value' } );
+		} );
+
+		expect( attributeRef.current ).toBe( 'value' );
+	} );
+} );

--- a/tests/utils/defer.test.tsx
+++ b/tests/utils/defer.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createDefer, type Defer } from '../../src/utils/defer';
+
+describe( 'createDefer', () => {
+	it( 'should resolve the promise with the provided value', async () => {
+		const value = 'test value';
+		const defer: Defer<string> = createDefer();
+
+		defer.resolve( value );
+
+		const result = await defer.promise;
+		expect( result ).toBe( value );
+	} );
+
+	it( 'should create a promise that can be resolved asynchronously', async () => {
+		const value = 'test value';
+		const defer: Defer<string> = createDefer();
+
+		setTimeout( () => {
+			defer.resolve( value );
+		}, 100 );
+
+		const result = await defer.promise;
+		expect( result ).toBe( value );
+	} );
+} );

--- a/tests/utils/mergeRefs.test.tsx
+++ b/tests/utils/mergeRefs.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { MutableRefObject } from 'react';
+
+import { describe, expect, it, vi } from 'vitest';
+import { mergeRefs } from '../../src/utils/mergeRefs';
+
+describe( 'mergeRefs', () => {
+	it( 'should call the callback ref with the provided value', () => {
+		const callbackRef = vi.fn();
+
+		mergeRefs( callbackRef )( 'test' );
+		expect( callbackRef ).toHaveBeenCalledWith( 'test' );
+	} );
+
+	it( 'should assign the value to the mutable ref object', () => {
+		const mutableRefObject: MutableRefObject<string | null> = { current: null };
+
+		mergeRefs( mutableRefObject )( 'test' );
+		expect( mutableRefObject.current ).toBe( 'test' );
+	} );
+
+	it( 'should assign the value to multiple refs', () => {
+		const callbackRef1 = vi.fn();
+		const mutableRefObject1 = { current: null };
+		const callbackRef2 = vi.fn();
+		const mutableRefObject2 = { current: null };
+
+		mergeRefs(
+			callbackRef1,
+			mutableRefObject1,
+			callbackRef2,
+			mutableRefObject2
+		)( 'test' );
+
+		expect( callbackRef1 ).toHaveBeenCalledWith( 'test' );
+		expect( mutableRefObject1.current ).toBe( 'test' );
+		expect( callbackRef2 ).toHaveBeenCalledWith( 'test' );
+		expect( mutableRefObject2.current ).toBe( 'test' );
+	} );
+
+	it( 'should handle null refs', () => {
+		const callbackRef = vi.fn();
+		const mutableRefObject = { current: null };
+
+		mergeRefs( callbackRef, null, mutableRefObject )( null );
+		expect( callbackRef ).toHaveBeenCalledWith( null );
+		expect( mutableRefObject.current ).toBe( null );
+	} );
+} );

--- a/tests/utils/once.test.tsx
+++ b/tests/utils/once.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { once } from '../../src/utils/once';
+
+describe( 'once', () => {
+	it( 'should execute the function only once', () => {
+		const mockFn = vi.fn();
+		const onceFn = once( mockFn );
+
+		onceFn();
+		onceFn();
+		onceFn();
+
+		expect( mockFn ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'should return the same result on subsequent calls', () => {
+		const mockFn = vi.fn().mockReturnValue( 'result' );
+		const onceFn = once( mockFn );
+
+		const result1 = onceFn();
+		const result2 = onceFn();
+		const result3 = onceFn();
+
+		expect( result1 ).toBe( 'result' );
+		expect( result2 ).toBe( 'result' );
+		expect( result3 ).toBe( 'result' );
+	} );
+} );

--- a/tests/utils/overwriteArray.test.tsx
+++ b/tests/utils/overwriteArray.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { overwriteArray } from '../../src/utils/overwriteArray';
+
+describe( 'overwriteArray', () => {
+	it( 'should clear the destination array and copy the elements from the source array', () => {
+		const source = [ 1, 2, 3 ];
+		const destination = [ 4, 5, 6 ];
+
+		const result = overwriteArray( source, destination );
+
+		expect( result ).toBe( destination );
+		expect( result ).toEqual( source );
+	} );
+} );

--- a/tests/utils/overwriteObject.test.tsx
+++ b/tests/utils/overwriteObject.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { overwriteObject } from '../../src/utils/overwriteObject';
+
+describe( 'overwriteObject', () => {
+	it( 'overwriteObject should clear the destination object and copy properties from the source object', () => {
+		const source = { a: 1, b: 2, c: 10 };
+		const destination = { a: 10, b: 3, c: 20 };
+
+		const result = overwriteObject( source, destination );
+
+		expect( result ).toBe( destination );
+		expect( result ).toEqual( { a: 1, b: 2, c: 10 } );
+	} );
+
+	it( 'should not override prototype properties', () => {
+		const source = { a: 1, b: 2, c: 10 };
+		const destination = Object.create( { a: 10, b: 3, c: 20 } );
+
+		const result = overwriteObject( source, destination );
+
+		expect( result ).toBe( destination );
+		expect( result ).toEqual( { a: 1, b: 2, c: 10 } );
+	} );
+
+	it( 'should remove properties from destination that are not present in source', () => {
+		const source = { a: 1, b: 2 };
+		const destination = { a: 10, b: 3, c: 20 };
+
+		const result = overwriteObject( source, destination );
+
+		expect( result ).toBe( destination );
+		expect( result ).toEqual( { a: 1, b: 2 } );
+	} );
+
+	it( 'should not set self referencing attributes which crashes Object.assign', () => {
+		const source = { a: 1, b: 2, c: 10, d: null as any };
+		const destination = { a: 10, b: 3, c: 20 };
+
+		source.d = destination;
+
+		const result = overwriteObject( source, destination );
+
+		expect( result ).toBe( destination );
+		expect( result ).toEqual( { a: 1, b: 2, c: 10 } );
+	} );
+} );

--- a/tests/utils/shallowCompareArrays.test.tsx
+++ b/tests/utils/shallowCompareArrays.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shallowCompareArrays } from '../../src/utils/shallowCompareArrays';
+
+describe( 'shallowCompareArrays', () => {
+	it( 'should return true if references are the same', () => {
+		const array = [ 1, 2, 3 ];
+		expect( shallowCompareArrays( array, array ) ).to.be.true;
+	} );
+
+	it( 'should return true for equal arrays', () => {
+		const array1 = [ 1, 2, 3 ];
+		const array2 = [ 1, 2, 3 ];
+
+		expect( shallowCompareArrays( array1, array2 ) ).to.be.true;
+	} );
+
+	it( 'should return false for different arrays', () => {
+		const array1 = [ 1, 2, 3 ];
+		const array2 = [ 1, 2, 4 ];
+		expect( shallowCompareArrays( array1, array2 ) ).to.be.false;
+	} );
+
+	it( 'should return false for arrays with different lengths', () => {
+		const array1 = [ 1, 2, 3 ];
+		const array2 = [ 1, 2 ];
+		expect( shallowCompareArrays( array1, array2 ) ).to.be.false;
+	} );
+
+	it( 'should return true for empty arrays', () => {
+		const array1: Array<number> = [];
+		const array2: Array<number> = [];
+		expect( shallowCompareArrays( array1, array2 ) ).to.be.true;
+	} );
+} );

--- a/tests/utils/uid.test.tsx
+++ b/tests/utils/uid.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { it, expect, describe } from 'vitest';
+import { uid } from '../../src/utils/uid';
+
+describe( 'uid', () => {
+	it( 'uid should return a string starting with "e"', () => {
+		const id = uid();
+		expect( id.startsWith( 'e' ) ).toBe( true );
+	} );
+
+	it( 'uid should return a string of length 33', () => {
+		const id = uid();
+		expect( id.length ).toBe( 33 );
+	} );
+
+	it( 'uid should return unique ids', () => {
+		const id1 = uid();
+		const id2 = uid();
+		expect( id1 ).not.toBe( id2 );
+	} );
+
+	it( 'uid should only contain hexadecimal characters', () => {
+		const id = uid();
+		const hexRegex = /^[a-fA-F0-9]+$/;
+		expect( hexRegex.test( id.substring( 1 ) ) ).toBe( true );
+	} );
+} );

--- a/tests/utils/uniq.test.tsx
+++ b/tests/utils/uniq.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { uniq } from '../../src/utils/uniq';
+
+describe( 'uniq', () => {
+	it( 'should remove duplicate elements from an array', () => {
+		const input = [ 1, 2, 2, 3, 4, 4, 5 ];
+		const expectedOutput = [ 1, 2, 3, 4, 5 ];
+
+		const result = uniq( input );
+
+		expect( result ).toEqual( expectedOutput );
+	} );
+
+	it( 'should return an empty array if the input is empty', () => {
+		const input: Array<number> = [];
+		const expectedOutput: Array<number> = [];
+
+		const result = uniq( input );
+
+		expect( result ).toEqual( expectedOutput );
+	} );
+} );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,9 @@ export default defineConfig( {
 			provider: 'istanbul',
 			include: [ 'src/*' ],
 			exclude: [ 'src/demos' ],
+			thresholds: {
+				100: true
+			},
 			reporter: [
 				'text-summary',
 				'html',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Restore 100% coverage in whole project after migration to ESM and new test suite. 

---

### Additional information

Previously, our test suite was returning incorrect coverage info. After migration to `vitest` it shows us that we have ~90% coverage percentage. This PR restores coverage to 100%. 