### PR TITLE
`CKEditorContext` element is not used properly in `useMultiRootEditor`

### DIFF
--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -365,8 +365,8 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 		}
 
 		const watchdog = ( () => {
-			if ( context instanceof props.editor.ContextWatchdog ) {
-				return new EditorWatchdogAdapter( context );
+			if ( isContextWatchdogReadyToUse( context ) ) {
+				return new EditorWatchdogAdapter( context.watchdog );
 			}
 
 			return new props.editor.EditorWatchdog( props.editor, props.watchdogConfig );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `CKEditorContext` element is not used properly in `useMultiRootEditor`. 

### Additional Information

Closes https://github.com/ckeditor/ckeditor5-react/issues/499.

1. This regression was not released, so no need to add it to changelog.
2. Proper tests are added here https://github.com/ckeditor/ckeditor5-react/pull/490, no need to refactor enzyme

