### PR TITLE
Change the UMD global name to `CKEDITOR_REACT`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig( {
 		// https://vitejs.dev/guide/build#library-mode
 		lib: {
 			entry: resolve( __dirname, 'src/index.ts' ),
-			name: 'CKEditor',
+			name: 'CKEDITOR_REACT',
 			fileName: 'index'
 		},
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Change the global name used in the UMD build from `CKEditor` to `CKEDITOR_REACT` to match the new convention. See ckeditor/ckeditor5#16736.

MINOR BREAKING CHANGE: Change the global name used in the UMD build from `CKEditor` to `CKEDITOR_REACT`.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
