### PR TITLE
Add `onTrackInitializedEditors` callback to `CKEditorContext`

### DIFF
--- a/demos/react/ContextDemo.tsx
+++ b/demos/react/ContextDemo.tsx
@@ -48,6 +48,9 @@ export default function ContextDemo( props: ContextDemoProps ): JSX.Element {
 			<CKEditorContext
 				context={ ClassicEditor.Context as any }
 				contextWatchdog={ ClassicEditor.ContextWatchdog as any }
+				onTrackInitializedEditors={ editors => {
+					console.log( 'Editors:', editors );
+				}}
 			>
 				<div className="buttons">
 					<button
@@ -59,6 +62,7 @@ export default function ContextDemo( props: ContextDemoProps ): JSX.Element {
 				</div>
 
 				<CKEditor
+					id='abc'
 					editor={ ClassicEditor as any }
 					data={ props.content }
 					onReady={ ( editor: any ) => {

--- a/src/ckeditor.tsx
+++ b/src/ckeditor.tsx
@@ -27,7 +27,7 @@ import {
 	ContextWatchdogContext,
 	isContextWatchdogInitializing,
 	isContextWatchdogReadyToUse
-} from './ckeditorcontext';
+} from './context/ckeditorcontext';
 
 const REACT_INTEGRATION_READ_ONLY_LOCK_ID = 'Lock from React integration (@ckeditor/ckeditor5-react)';
 

--- a/src/context/useInitializedCKEditorsMap.ts
+++ b/src/context/useInitializedCKEditorsMap.ts
@@ -1,0 +1,102 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { useEffect } from 'react';
+import { useRefSafeCallback } from '../hooks/useRefSafeCallback';
+
+import type { CollectionAddEvent, Context, Editor } from 'ckeditor5';
+import type { ContextWatchdogValue } from './ckeditorcontext';
+
+/**
+ * A hook that listens for the editor initialization and destruction events and updates the editors map.
+ *
+ * @param config The configuration of the hook.
+ * @param config.currentContextWatchdog The current context watchdog value.
+ * @param config.onChangeEditorsMap The function that updates the editors map.
+ * @example
+ * ```ts
+ * useInitializedCKEditorsMap( {
+ * 	currentContextWatchdog,
+ * 	onTrackInitializedEditors: ( editors, context ) => {
+ * 		console.log( 'Editors:', editors );
+ * 	}
+ * } );
+ * ```
+ */
+export const useInitializedCKEditorsMap = <TContext extends Context>(
+	{
+		currentContextWatchdog,
+		onTrackInitializedEditors
+	}: InitializedContextEditorsConfig<TContext>
+): void => {
+	// We need to use the safe callback to prevent the stale closure problem.
+	const onTrackInitializedEditorsSafe = useRefSafeCallback( onTrackInitializedEditors || ( () => {} ) );
+
+	useEffect( () => {
+		if ( currentContextWatchdog.status !== 'initialized' ) {
+			return;
+		}
+
+		const { watchdog } = currentContextWatchdog;
+		const editors = watchdog?.context?.editors;
+
+		if ( !editors ) {
+			return;
+		}
+
+		// Get the initialized editors from
+		const getInitializedContextEditors = () => [ ...editors ].reduce(
+			( map, editor ) => {
+				if ( editor.state === 'ready' ) {
+					map.set( editor.id, editor );
+				}
+
+				return map;
+			},
+			new Map<string, Editor>()
+		);
+
+		// The function that is called when the editor status changes.
+		const onEditorStatusChange = () => {
+			onTrackInitializedEditorsSafe(
+				getInitializedContextEditors(),
+				watchdog.context! as TContext
+			);
+		};
+
+		// Add the existing editors to the map.
+		const onAddEditor = ( _: unknown, editor: Editor ) => {
+			editor.once( 'ready', onEditorStatusChange, { priority: 'lowest' } );
+			editor.once( 'destroy', onEditorStatusChange, { priority: 'lowest' } );
+		};
+
+		editors.on<CollectionAddEvent<Editor>>( 'add', onAddEditor );
+
+		return () => {
+			editors.off( 'add', onAddEditor );
+		};
+	}, [ currentContextWatchdog ] );
+};
+
+/**
+ * A map of initialized editors.
+ */
+type InitializedEditorsMap = Map<string, Editor>;
+
+/**
+ * The configuration of the `useInitializedCKEditorsMap` hook.
+ */
+export type InitializedContextEditorsConfig<TContext extends Context> = {
+
+	/**
+	 * The current context watchdog value.
+	 */
+	currentContextWatchdog: ContextWatchdogValue;
+
+	/**
+	 * The callback called when the editors map changes.
+	 */
+	onTrackInitializedEditors?: ( editors: InitializedEditorsMap, context: TContext ) => void;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,5 @@
  */
 
 export { default as CKEditor } from './ckeditor';
-export { default as CKEditorContext } from './ckeditorcontext';
+export { default as CKEditorContext } from './context/ckeditorcontext';
 export { default as useMultiRootEditor, type MultiRootHookProps, type MultiRootHookReturns } from './useMultiRootEditor';

--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -21,7 +21,7 @@ import type {
 	EventInfo
 } from 'ckeditor5';
 
-import { ContextWatchdogContext, isContextWatchdogReadyToUse } from './ckeditorcontext';
+import { ContextWatchdogContext, isContextWatchdogReadyToUse } from './context/ckeditorcontext';
 import { EditorWatchdogAdapter } from './ckeditor';
 
 import type { EditorSemaphoreMountResult } from './lifecycle/LifeCycleEditorSemaphore';

--- a/tests/context/ckeditorcontext.test.tsx
+++ b/tests/context/ckeditorcontext.test.tsx
@@ -11,15 +11,15 @@ import CKEditorContext, {
 	type Props,
 	type ContextWatchdogValue,
 	type ExtractContextWatchdogValueByStatus
-} from '../src/ckeditorcontext.tsx';
+} from '../../src/context/ckeditorcontext.tsx';
 
-import CKEditor from '../src/ckeditor.tsx';
-import MockedEditor from './_utils/editor.js';
+import CKEditor from '../../src/ckeditor.tsx';
+import MockedEditor from '../_utils/editor.js';
 import { ContextWatchdog, CKEditorError } from 'ckeditor5';
-import turnOffDefaultErrorCatching from './_utils/turnoffdefaulterrorcatching.js';
-import ContextMock, { DeferredContextMock } from './_utils/context.js';
-import { timeout } from './_utils/timeout.js';
-import { PromiseManager } from './_utils/promisemanager.js';
+import turnOffDefaultErrorCatching from '../_utils/turnoffdefaulterrorcatching.js';
+import ContextMock, { DeferredContextMock } from '../_utils/context.js';
+import { timeout } from '../_utils/timeout.js';
+import { PromiseManager } from '../_utils/promisemanager.js';
 
 const MockEditor = MockedEditor as any;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add `onTrackInitializedEditors` callback to `CKEditorContext`. Closes https://github.com/ckeditor/ckeditor5-react/issues/513

---

### Additional information

During React 19 refactor, it was discovered that `CKEditorContext` must be initialized _before_ rendering the rest of React tree. It was because in the `StrictMode` the `CKEditorContext` was recreated in small amount of the time which was causing crashes in nested editors (which were using wrong reference of `CKEditorContext` during initialization).

This PR adds `onTrackInitializedEditors` callback to  `CKEditorContext` that is fired after any initialization or destruction of editor. 
