### PR TITLE
Restore restarted watchdog editor with current react state

### DIFF
--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -380,7 +380,13 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 			current: 0
 		};
 
-		watchdog.setCreator( async ( data, config ) => {
+		// Keeping using `data` from creator function callback seems to be a good idea in theory,
+		// but in practice, it leads to instability. The `data` object can be changed during the editor
+		// initialization, which can lead to unexpected reset of value in the editor, that do not match
+		// with the current react state. To prevent this, we are using the `data` from the hook state.
+		// It's not super optimal, but it's the most stable solution at this moment.
+		// See more: https://github.com/ckeditor/ckeditor5-react/issues/542
+		watchdog.setCreator( async ( _, config ) => {
 			const { onAfterDestroy } = props;
 
 			if ( totalRestartsRef.current > 0 && onAfterDestroy && editorRefs.instance.current ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent potential crashes of `useMultiRootEditor` during the initialization phase when setting the new state of the multi-root editor with an attached watchdog. Closes https://github.com/ckeditor/ckeditor5-react/issues/542

---

### Additional information

It appears that some of our tests are causing random restarts of the editor. An example of such a restart might occur when setting some data while the component has not fully rendered the entire CKEditor, and the semaphore begins destroying it while running in the watchdog context.

This PR resets the reinitialized editor data to the one defined in the React state (data is defined in the upper scope). This change seems to make our tests more stable and should be harmless.
