### PR TITLE
No longer duplicate editor when error occurs in `onReady` callback.

### DIFF
--- a/src/ckeditor.tsx
+++ b/src/ckeditor.tsx
@@ -183,8 +183,14 @@ export default class CKEditor<TEditor extends Editor> extends React.Component<Pr
 			afterMount: ( { mountResult } ) => {
 				const { onReady } = this.props;
 
-				if ( onReady && this.domContainer.current !== null ) {
+				if ( !onReady || this.domContainer.current === null ) {
+					return;
+				}
+
+				try {
 					onReady( mountResult.instance );
+				} catch ( err ) {
+					console.error( err );
 				}
 			},
 			unmount: async ( { element, mountResult } ) => {

--- a/tests/ckeditor.test.tsx
+++ b/tests/ckeditor.test.tsx
@@ -549,6 +549,51 @@ describe( '<CKEditor> Component', () => {
 
 				expect( editor ).to.equal( editorInstance );
 			} );
+
+			it( 'should catch and log errors thrown in onReady callback', async () => {
+				const error = new Error( 'Test error' );
+				const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+				const editorInstance = new MockEditor();
+
+				const defer = createDefer();
+
+				vi.spyOn( MockEditor, 'create' ).mockResolvedValue( editorInstance );
+
+				component = render(
+					<CKEditor
+						editor={MockEditor}
+						onReady={() => {
+							defer.resolve();
+							throw error;
+						}}
+					/>
+				);
+
+				await defer.promise;
+
+				expect( consoleErrorSpy ).toHaveBeenCalledOnce();
+				expect( consoleErrorSpy ).toHaveBeenCalledWith( error );
+			} );
+
+			it( 'should not log errors when onReady callback executes successfully', async () => {
+				const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+				const editorInstance = new MockEditor();
+
+				vi.spyOn( MockEditor, 'create' ).mockResolvedValue( editorInstance );
+
+				component = render(
+					<CKEditor
+						editor={MockEditor}
+						onReady={manager.resolveOnRun( () => {
+							// Successful callback
+						} )}
+					/>
+				);
+
+				await manager.all();
+
+				expect( consoleErrorSpy ).not.toHaveBeenCalled();
+			} );
 		} );
 
 		describe( '#onChange', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: No longer duplicate editors when error occurs in `onReady` callback.

---

### Additional information

Throwing exceptions inside `onReady` might lock semaphore forever, leading to weird artefacts like duplicated elements and too soon watchdog restarts. This PR ensures that `onReady` is exception free.  

Closes https://github.com/cksource/ckeditor5-commercial/issues/6796
