### PR TITLE
Add retries to flaky multiroot semaphores tests.

### DIFF
--- a/tests/useMultiRootEditor.test.tsx
+++ b/tests/useMultiRootEditor.test.tsx
@@ -931,7 +931,7 @@ describe( 'useMultiRootEditor', () => {
 					editor: SlowEditor
 				} ) );
 
-				await timeout( 100 );
+				await timeout( 500 );
 
 				// Depending on the execution order on the event loop this `setData` might be delayed by the React engine.
 				// It happens only if event loop is busy and React has to wait for the next tick a little bit longer than usual.
@@ -942,9 +942,9 @@ describe( 'useMultiRootEditor', () => {
 					content: ''
 				} );
 
-				await timeout( 200 );
+				await timeout( 500 );
 
-				deferInitialization.resolve();
+				await deferInitialization.resolve();
 
 				await waitFor( () => {
 					expect( result.current.editor ).to.be.instanceof( SlowEditor );

--- a/tests/useMultiRootEditor.test.tsx
+++ b/tests/useMultiRootEditor.test.tsx
@@ -896,7 +896,7 @@ describe( 'useMultiRootEditor', () => {
 
 	describe( 'semaphores', () => {
 		const testSemaphoreForWatchdog = enableWatchdog => {
-			it( 'should assign properly `data` property to editor even if it is still mounting', { retry: 3 }, async () => {
+			it( 'should assign `data` property to the editor even if it is still mounting', { retry: 3 }, async () => {
 				const deferInitialization = createDefer();
 
 				class SlowEditor extends TestMultiRootEditor {
@@ -933,9 +933,9 @@ describe( 'useMultiRootEditor', () => {
 
 				await timeout( 500 );
 
-				// Depending on the execution order on the event loop this `setData` might be delayed by the React engine.
-				// It happens only if event loop is busy and React has to wait for the next tick a little bit longer than usual.
-				// It does not play well with `waitFor` below so we added few retries to make it more stable.
+				// Depending on the execution order on the event loop, this `setData` might be delayed by the React engine.
+				// It happens only if the event loop is busy and React has to wait for the next tick a little bit longer than usual.
+				// It does not play well with the `waitFor` below, so we added a few retries to make it more stable.
 				// It should not be a problem in real life, as it is a rare case and might be solved in future React versions.
 				result.current.setData( {
 					intro: 'Hello World!',

--- a/tests/useMultiRootEditor.test.tsx
+++ b/tests/useMultiRootEditor.test.tsx
@@ -896,7 +896,7 @@ describe( 'useMultiRootEditor', () => {
 
 	describe( 'semaphores', () => {
 		const testSemaphoreForWatchdog = enableWatchdog => {
-			it( 'should assign properly `data` property to editor even if it is still mounting', async () => {
+			it( 'should assign properly `data` property to editor even if it is still mounting', { retry: 3 }, async () => {
 				const deferInitialization = createDefer();
 
 				class SlowEditor extends TestMultiRootEditor {
@@ -933,6 +933,10 @@ describe( 'useMultiRootEditor', () => {
 
 				await timeout( 100 );
 
+				// Depending on the execution order on the event loop this `setData` might be delayed by the React engine.
+				// It happens only if event loop is busy and React has to wait for the next tick a little bit longer than usual.
+				// It does not play well with `waitFor` below so we added few retries to make it more stable.
+				// It should not be a problem in real life, as it is a rare case and might be solved in future React versions.
 				result.current.setData( {
 					intro: 'Hello World!',
 					content: ''

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,9 @@ export default defineConfig( {
 		include: [
 			'tests/**/*.test.[j|t]sx'
 		],
+		sequence: {
+			shuffle: true
+		},
 		coverage: {
 			provider: 'istanbul',
 			include: [ 'src/*' ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,6 +66,7 @@ export default defineConfig( {
 			},
 			reporter: [
 				'text-summary',
+				'text',
 				'html',
 				'lcovonly',
 				'json'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Add `retry` option to flaky `multiroot` test, extend delay between assertions. 
Tests: Randomize the order of the tests, to prevent incorrect dependencies across tests. 

---

### Additional information

This test tests quite rare scenario when `setData` is being called when editor is not initialized. In theory - it is possible, but I haven't managed to reproduce this in the real world. At this moment, there were no reports about incorrect behavior, so it's safe enough to retry it a few times.
