### PR TITLE
Fix inconsistent `onError` callback

### DIFF
--- a/src/lifecycle/LifeCycleElementSemaphore.ts
+++ b/src/lifecycle/LifeCycleElementSemaphore.ts
@@ -120,7 +120,7 @@ export class LifeCycleElementSemaphore<R> {
 	}
 
 	/**
-	 * Getter for {@link #_releaseLock}.
+	 * Resets the semaphore to its initial state.
 	 */
 	public discard(): void {
 		this._value = null;

--- a/src/lifecycle/LifeCycleElementSemaphore.ts
+++ b/src/lifecycle/LifeCycleElementSemaphore.ts
@@ -317,19 +317,19 @@ export type LifeCycleAsyncOperators<R> = {
 	mount: () => Promise<R>;
 
 	/**
-	 * Optional method that is called after the editor is mounted.
-	 * It is passed the result of the mount method as an argument.
+	 * The optional method is called after the editor is mounted.
+	 * The result of the mount method is passed on as an argument.
 	 */
 	afterMount?: ( result: LifeCyclePostMountAttrs<R> ) => Promise<void> | void;
 
 	/**
-	 * Unmount method that is called when the editor is destroyed.
-	 * It is passed the result of the mount method as an argument.
+	 * The unmount method is called when the editor is destroyed.
+	 * The result of the mount method is passed on as an argument.
 	 */
 	unmount: ( result: LifeCyclePostMountAttrs<R> ) => Promise<void>;
 
 	/**
-	 * Optional method to check if the editor value is valid.
+	 * The optional method is used to check if the editor value is valid.
 	 * If this method returns false, callbacks registered with runAfterMount will not be executed.
 	 * This helps prevent errors in race conditions where the editor was destroyed during initialization.
 	 */

--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -631,6 +631,7 @@ export const EditorEditable = memo( forwardRef( ( { id, semaphore, rootName }: {
 		} );
 
 		return () => {
+			/* istanbul ignore next -- @preserve: It depends on the version of the React and may not happen all of the times. */
 			if ( editor && editor.state !== 'destroyed' && innerRef.current ) {
 				const root = editor.model.document.getRoot( rootName );
 

--- a/tests/ckeditor.test.tsx
+++ b/tests/ckeditor.test.tsx
@@ -798,6 +798,31 @@ describe( '<CKEditor> Component', () => {
 				expect( details.willEditorRestart ).to.equal( false );
 			} );
 
+			it( 'calls the callback if specified when an error occurs (disabledWatchdog)', async () => {
+				let error;
+				let details;
+				const originalError = new Error( 'Error was thrown.' );
+
+				vi.spyOn( MockEditor, 'create' ).mockRejectedValue( originalError );
+
+				component = render(
+					<CKEditor
+						disableWatchdog
+						editor={MockEditor}
+						onError={manager.resolveOnRun( ( err, dets ) => {
+							error = err;
+							details = dets;
+						} )}
+					/>
+				);
+
+				await manager.all();
+
+				expect( error ).to.equal( error );
+				expect( details.phase ).to.equal( 'initialization' );
+				expect( details.willEditorRestart ).to.equal( false );
+			} );
+
 			it( 'calls the callback if the runtime error occurs', async () => {
 				component = render(
 					<CKEditor

--- a/tests/ckeditor.test.tsx
+++ b/tests/ckeditor.test.tsx
@@ -441,9 +441,8 @@ describe( '<CKEditor> Component', () => {
 			await new Promise( res => setTimeout( res ) );
 
 			expect( consoleErrorStub ).toHaveBeenCalledOnce();
-			expect( consoleErrorStub.mock.calls[ 0 ][ 0 ] ).to.equal( error );
-			expect( consoleErrorStub.mock.calls[ 0 ][ 1 ].phase ).to.equal( 'initialization' );
-			expect( consoleErrorStub.mock.calls[ 0 ][ 1 ].willEditorRestart ).to.equal( false );
+			expect( consoleErrorStub.mock.calls[ 0 ][ 0 ] ).to.equal( 'CKEditor mounting error:' );
+			expect( consoleErrorStub.mock.calls[ 0 ][ 1 ] ).to.equal( error );
 		} );
 
 		it( 'passes the specified editor class to the watchdog feature', async () => {
@@ -785,11 +784,10 @@ describe( '<CKEditor> Component', () => {
 				component = render(
 					<CKEditor
 						editor={MockEditor}
-						onError={( err, dets ) => {
+						onError={manager.resolveOnRun( ( err, dets ) => {
 							error = err;
 							details = dets;
-						}}
-						onReady={manager.resolveOnRun()}
+						} )}
 					/>
 				);
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `onError` was not called when `disableWatchdog` was set to `true`. #591 
Fix: `onError` was not called when watchdog initialization failed. #591 
Fix: Editor no longer crashes when the `disable` option is changed during initialization.

### Additional information

Caused by #591 
