### PR TITLE
Update imports to match CKEditor 5 v46.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@ckeditor/ckeditor5-integrations-common": "^2.2.2"
   },
   "peerDependencies": {
-    "ckeditor5": ">=42.0.0 || ^0.0.0-nightly",
+    "ckeditor5": ">=46.0.0 || ^0.0.0-nightly",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
@@ -48,8 +48,8 @@
     "@vitest/browser": "^2.1.9",
     "@vitest/coverage-istanbul": "^2.1.4",
     "@vitest/ui": "^2.1.4",
-    "ckeditor5": "^45.0.0",
-    "ckeditor5-premium-features": "^45.0.0",
+    "ckeditor5": "^46.0.0-alpha.0",
+    "ckeditor5-premium-features": "^46.0.0-alpha.0",
     "coveralls": "^3.1.1",
     "eslint": "^9.26.0",
     "eslint-config-ckeditor5": "^10.0.0",

--- a/src/ckeditor.tsx
+++ b/src/ckeditor.tsx
@@ -9,11 +9,9 @@ import type {
 	EventInfo,
 	Editor,
 	EditorConfig,
-	DocumentChangeEvent,
 	EditorWatchdog,
 	ContextWatchdog,
-	WatchdogConfig,
-	EditorCreatorFunction
+	WatchdogConfig
 } from 'ckeditor5';
 
 import type { EditorSemaphoreMountResult } from './lifecycle/LifeCycleEditorSemaphore.js';
@@ -326,7 +324,7 @@ export default class CKEditor<TEditor extends Editor> extends React.Component<Pr
 				const modelDocument = editor.model.document;
 				const viewDocument = editor.editing.view.document;
 
-				modelDocument.on<DocumentChangeEvent>( 'change:data', event => {
+				modelDocument.on( 'change:data', event => {
 					/* istanbul ignore else -- @preserve */
 					if ( this.props.onChange ) {
 						this.props.onChange( event, editor );
@@ -479,7 +477,7 @@ export class EditorWatchdogAdapter<TEditor extends Editor> {
 	/**
 	 * A watchdog's editor creator function.
 	 */
-	private _creator?: EditorCreatorFunction;
+	private _creator?: AdapterEditorCreatorFunction;
 
 	/**
 	 * @param contextWatchdog The context watchdog instance that will be wrapped into editor watchdog API.
@@ -492,7 +490,7 @@ export class EditorWatchdogAdapter<TEditor extends Editor> {
 	/**
 	 *  @param creator A watchdog's editor creator function.
 	 */
-	public setCreator( creator: EditorCreatorFunction ): void {
+	public setCreator( creator: AdapterEditorCreatorFunction ): void {
 		this._creator = creator;
 	}
 
@@ -550,3 +548,8 @@ export class EditorWatchdogAdapter<TEditor extends Editor> {
 		return this._contextWatchdog.getItem( this._id ) as TEditor;
 	}
 }
+
+type AdapterEditorCreatorFunction<TEditor = Editor> = (
+	elementOrData: HTMLElement | string | Record<string, string> | Record<string, HTMLElement>,
+	config: EditorConfig
+) => Promise<TEditor>;

--- a/src/useMultiRootEditor.tsx
+++ b/src/useMultiRootEditor.tsx
@@ -13,9 +13,8 @@ import { overwriteArray, overwriteObject, uniq } from '@ckeditor/ckeditor5-integ
 import type {
 	InlineEditableUIView,
 	EditorConfig,
-	DocumentChangeEvent,
-	Writer,
-	RootElement,
+	ModelWriter,
+	ModelRootElement,
 	WatchdogConfig,
 	AddRootEvent,
 	DetachRootEvent,
@@ -170,14 +169,14 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 
 			modelDocument.differ.getChanges()
 				.forEach( change => {
-					let root: RootElement;
+					let root: ModelRootElement;
 
 					/* istanbul ignore else -- @preserve */
 					if ( change.type == 'insert' || change.type == 'remove' ) {
-						root = change.position.root as RootElement;
+						root = change.position.root as ModelRootElement;
 					} else {
 						// Must be `attribute` diff item.
-						root = change.range.root as RootElement;
+						root = change.range.root as ModelRootElement;
 					}
 
 					// Getting data from a not attached root will trigger a warning.
@@ -226,7 +225,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 	/**
 	 * Callback function for handling an added root.
 	 */
-	const onAddRoot = useRefSafeCallback( ( editor: MultiRootEditor, _evt: EventInfo, root: RootElement ): void => {
+	const onAddRoot = useRefSafeCallback( ( editor: MultiRootEditor, _evt: EventInfo, root: ModelRootElement ): void => {
 		const rootName = root.rootName;
 
 		if ( !props.disableTwoWayDataBinding ) {
@@ -245,7 +244,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 	/**
 	 * Callback function for handling a detached root.
 	 */
-	const onDetachRoot = useRefSafeCallback( ( _editor: MultiRootEditor, _evt: EventInfo, root: RootElement ): void => {
+	const onDetachRoot = useRefSafeCallback( ( _editor: MultiRootEditor, _evt: EventInfo, root: ModelRootElement ): void => {
 		const rootName = root.rootName;
 
 		if ( !props.disableTwoWayDataBinding ) {
@@ -302,7 +301,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 				const modelDocument = editor.model.document;
 				const viewDocument = editor.editing.view.document;
 
-				modelDocument.on<DocumentChangeEvent>( 'change:data', evt => onChangeData( editor, evt ) );
+				modelDocument.on( 'change:data', evt => onChangeData( editor, evt ) );
 
 				editor.on<AddRootEvent>( 'addRoot', ( evt, root ) => onAddRoot( editor, evt, root ) );
 				editor.on<DetachRootEvent>( 'detachRoot', ( evt, root ) => onDetachRoot( editor, evt, root ) );
@@ -550,7 +549,7 @@ const useMultiRootEditor = ( props: MultiRootHookProps ): MultiRootHookReturns =
 				instance.data.set( dataToUpdate, { suppressErrorInCollaboration: true } as any );
 			};
 
-			const _updateEditorAttributes = ( writer: Writer, roots: Array<string> ) => {
+			const _updateEditorAttributes = ( writer: ModelWriter, roots: Array<string> ) => {
 				roots.forEach( rootName => {
 					Object.keys( attributes![ rootName ] ).forEach( attr => {
 						instance.registerRootAttribute( attr );

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,370 +62,363 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-sdk/client-bedrock-runtime@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.621.0.tgz#dce8237ee890c194b55948157318d9109ee99295"
-  integrity sha512-08QQhvnY3WQvIKX3rdzPcOwq13rD16jL63U2itpciNPVAlsDdw/4cUnbVSW+h9V/Lhb9LmlmbbbYdI3ZvGW+7A==
+"@aws-sdk/client-bedrock-runtime@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.823.0.tgz#a666f98b880076aec84bf2fabd4538f5d40bd282"
+  integrity sha512-mA5ZqVof+M1Oje0tvu/GcD44boQJDUErN5oIDwHH/IV9pvgAB4Dp8zZyQztd/75rzFb5/TUeiWfj8bN+JPnx3A==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/client-sso-oidc" "3.621.0"
-    "@aws-sdk/client-sts" "3.621.0"
-    "@aws-sdk/core" "3.621.0"
-    "@aws-sdk/credential-provider-node" "3.621.0"
-    "@aws-sdk/middleware-host-header" "3.620.0"
-    "@aws-sdk/middleware-logger" "3.609.0"
-    "@aws-sdk/middleware-recursion-detection" "3.620.0"
-    "@aws-sdk/middleware-user-agent" "3.620.0"
-    "@aws-sdk/region-config-resolver" "3.614.0"
-    "@aws-sdk/types" "3.609.0"
-    "@aws-sdk/util-endpoints" "3.614.0"
-    "@aws-sdk/util-user-agent-browser" "3.609.0"
-    "@aws-sdk/util-user-agent-node" "3.614.0"
-    "@smithy/config-resolver" "^3.0.5"
-    "@smithy/core" "^2.3.1"
-    "@smithy/eventstream-serde-browser" "^3.0.5"
-    "@smithy/eventstream-serde-config-resolver" "^3.0.3"
-    "@smithy/eventstream-serde-node" "^3.0.4"
-    "@smithy/fetch-http-handler" "^3.2.4"
-    "@smithy/hash-node" "^3.0.3"
-    "@smithy/invalid-dependency" "^3.0.3"
-    "@smithy/middleware-content-length" "^3.0.5"
-    "@smithy/middleware-endpoint" "^3.1.0"
-    "@smithy/middleware-retry" "^3.0.13"
-    "@smithy/middleware-serde" "^3.0.3"
-    "@smithy/middleware-stack" "^3.0.3"
-    "@smithy/node-config-provider" "^3.1.4"
-    "@smithy/node-http-handler" "^3.1.4"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/smithy-client" "^3.1.11"
-    "@smithy/types" "^3.3.0"
-    "@smithy/url-parser" "^3.0.3"
-    "@smithy/util-base64" "^3.0.0"
-    "@smithy/util-body-length-browser" "^3.0.0"
-    "@smithy/util-body-length-node" "^3.0.0"
-    "@smithy/util-defaults-mode-browser" "^3.0.13"
-    "@smithy/util-defaults-mode-node" "^3.0.13"
-    "@smithy/util-endpoints" "^2.0.5"
-    "@smithy/util-middleware" "^3.0.3"
-    "@smithy/util-retry" "^3.0.3"
-    "@smithy/util-stream" "^3.1.3"
-    "@smithy/util-utf8" "^3.0.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/credential-provider-node" "3.823.0"
+    "@aws-sdk/eventstream-handler-node" "3.821.0"
+    "@aws-sdk/middleware-eventstream" "3.821.0"
+    "@aws-sdk/middleware-host-header" "3.821.0"
+    "@aws-sdk/middleware-logger" "3.821.0"
+    "@aws-sdk/middleware-recursion-detection" "3.821.0"
+    "@aws-sdk/middleware-user-agent" "3.823.0"
+    "@aws-sdk/region-config-resolver" "3.821.0"
+    "@aws-sdk/types" "3.821.0"
+    "@aws-sdk/util-endpoints" "3.821.0"
+    "@aws-sdk/util-user-agent-browser" "3.821.0"
+    "@aws-sdk/util-user-agent-node" "3.823.0"
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/core" "^3.5.1"
+    "@smithy/eventstream-serde-browser" "^4.0.4"
+    "@smithy/eventstream-serde-config-resolver" "^4.1.2"
+    "@smithy/eventstream-serde-node" "^4.0.4"
+    "@smithy/fetch-http-handler" "^5.0.4"
+    "@smithy/hash-node" "^4.0.4"
+    "@smithy/invalid-dependency" "^4.0.4"
+    "@smithy/middleware-content-length" "^4.0.4"
+    "@smithy/middleware-endpoint" "^4.1.9"
+    "@smithy/middleware-retry" "^4.1.10"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/node-http-handler" "^4.0.6"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.1"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.17"
+    "@smithy/util-defaults-mode-node" "^4.0.17"
+    "@smithy/util-endpoints" "^3.0.6"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.5"
+    "@smithy/util-stream" "^4.2.2"
+    "@smithy/util-utf8" "^4.0.0"
+    "@types/uuid" "^9.0.1"
     tslib "^2.6.2"
+    uuid "^9.0.1"
 
-"@aws-sdk/client-sso-oidc@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.621.0.tgz#3fa3d468fbebbd93a5f75c1d51b63cc7af3ef17b"
-  integrity sha512-mMjk3mFUwV2Y68POf1BQMTF+F6qxt5tPu6daEUCNGC9Cenk3h2YXQQoS4/eSyYzuBiYk3vx49VgleRvdvkg8rg==
+"@aws-sdk/client-sso@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.823.0.tgz#a2ffb5e19f5729198ea4ab0360b6a9709aeeb5a6"
+  integrity sha512-dBWdsbyGw8rPfdCsZySNtTOGQK4EZ8lxB/CneSQWRBPHgQ+Ys88NXxImO8xfWO7Itt1eh8O7UDTZ9+smcvw2pw==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "3.621.0"
-    "@aws-sdk/credential-provider-node" "3.621.0"
-    "@aws-sdk/middleware-host-header" "3.620.0"
-    "@aws-sdk/middleware-logger" "3.609.0"
-    "@aws-sdk/middleware-recursion-detection" "3.620.0"
-    "@aws-sdk/middleware-user-agent" "3.620.0"
-    "@aws-sdk/region-config-resolver" "3.614.0"
-    "@aws-sdk/types" "3.609.0"
-    "@aws-sdk/util-endpoints" "3.614.0"
-    "@aws-sdk/util-user-agent-browser" "3.609.0"
-    "@aws-sdk/util-user-agent-node" "3.614.0"
-    "@smithy/config-resolver" "^3.0.5"
-    "@smithy/core" "^2.3.1"
-    "@smithy/fetch-http-handler" "^3.2.4"
-    "@smithy/hash-node" "^3.0.3"
-    "@smithy/invalid-dependency" "^3.0.3"
-    "@smithy/middleware-content-length" "^3.0.5"
-    "@smithy/middleware-endpoint" "^3.1.0"
-    "@smithy/middleware-retry" "^3.0.13"
-    "@smithy/middleware-serde" "^3.0.3"
-    "@smithy/middleware-stack" "^3.0.3"
-    "@smithy/node-config-provider" "^3.1.4"
-    "@smithy/node-http-handler" "^3.1.4"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/smithy-client" "^3.1.11"
-    "@smithy/types" "^3.3.0"
-    "@smithy/url-parser" "^3.0.3"
-    "@smithy/util-base64" "^3.0.0"
-    "@smithy/util-body-length-browser" "^3.0.0"
-    "@smithy/util-body-length-node" "^3.0.0"
-    "@smithy/util-defaults-mode-browser" "^3.0.13"
-    "@smithy/util-defaults-mode-node" "^3.0.13"
-    "@smithy/util-endpoints" "^2.0.5"
-    "@smithy/util-middleware" "^3.0.3"
-    "@smithy/util-retry" "^3.0.3"
-    "@smithy/util-utf8" "^3.0.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/middleware-host-header" "3.821.0"
+    "@aws-sdk/middleware-logger" "3.821.0"
+    "@aws-sdk/middleware-recursion-detection" "3.821.0"
+    "@aws-sdk/middleware-user-agent" "3.823.0"
+    "@aws-sdk/region-config-resolver" "3.821.0"
+    "@aws-sdk/types" "3.821.0"
+    "@aws-sdk/util-endpoints" "3.821.0"
+    "@aws-sdk/util-user-agent-browser" "3.821.0"
+    "@aws-sdk/util-user-agent-node" "3.823.0"
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/core" "^3.5.1"
+    "@smithy/fetch-http-handler" "^5.0.4"
+    "@smithy/hash-node" "^4.0.4"
+    "@smithy/invalid-dependency" "^4.0.4"
+    "@smithy/middleware-content-length" "^4.0.4"
+    "@smithy/middleware-endpoint" "^4.1.9"
+    "@smithy/middleware-retry" "^4.1.10"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/node-http-handler" "^4.0.6"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.1"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.17"
+    "@smithy/util-defaults-mode-node" "^4.0.17"
+    "@smithy/util-endpoints" "^3.0.6"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.5"
+    "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@aws-sdk/client-sso@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.621.0.tgz#c0eefeb9adcbc6bb7c91c32070404c8c91846825"
-  integrity sha512-xpKfikN4u0BaUYZA9FGUMkkDmfoIP0Q03+A86WjqDWhcOoqNA1DkHsE4kZ+r064ifkPUfcNuUvlkVTEoBZoFjA==
+"@aws-sdk/core@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.823.0.tgz#4e57ce2a97c9c5967ed2b200ece121420e09d492"
+  integrity sha512-1Cf4w8J7wYexz0KU3zpaikHvldGXQEjFldHOhm0SBGRy7qfYNXecfJAamccF7RdgLxKGgkv5Pl9zX/Z/DcW9zg==
   dependencies:
-    "@aws-crypto/sha256-browser" "5.2.0"
-    "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "3.621.0"
-    "@aws-sdk/middleware-host-header" "3.620.0"
-    "@aws-sdk/middleware-logger" "3.609.0"
-    "@aws-sdk/middleware-recursion-detection" "3.620.0"
-    "@aws-sdk/middleware-user-agent" "3.620.0"
-    "@aws-sdk/region-config-resolver" "3.614.0"
-    "@aws-sdk/types" "3.609.0"
-    "@aws-sdk/util-endpoints" "3.614.0"
-    "@aws-sdk/util-user-agent-browser" "3.609.0"
-    "@aws-sdk/util-user-agent-node" "3.614.0"
-    "@smithy/config-resolver" "^3.0.5"
-    "@smithy/core" "^2.3.1"
-    "@smithy/fetch-http-handler" "^3.2.4"
-    "@smithy/hash-node" "^3.0.3"
-    "@smithy/invalid-dependency" "^3.0.3"
-    "@smithy/middleware-content-length" "^3.0.5"
-    "@smithy/middleware-endpoint" "^3.1.0"
-    "@smithy/middleware-retry" "^3.0.13"
-    "@smithy/middleware-serde" "^3.0.3"
-    "@smithy/middleware-stack" "^3.0.3"
-    "@smithy/node-config-provider" "^3.1.4"
-    "@smithy/node-http-handler" "^3.1.4"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/smithy-client" "^3.1.11"
-    "@smithy/types" "^3.3.0"
-    "@smithy/url-parser" "^3.0.3"
-    "@smithy/util-base64" "^3.0.0"
-    "@smithy/util-body-length-browser" "^3.0.0"
-    "@smithy/util-body-length-node" "^3.0.0"
-    "@smithy/util-defaults-mode-browser" "^3.0.13"
-    "@smithy/util-defaults-mode-node" "^3.0.13"
-    "@smithy/util-endpoints" "^2.0.5"
-    "@smithy/util-middleware" "^3.0.3"
-    "@smithy/util-retry" "^3.0.3"
-    "@smithy/util-utf8" "^3.0.0"
-    tslib "^2.6.2"
-
-"@aws-sdk/client-sts@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.621.0.tgz#2994f601790893901704c5df56c837e89f279952"
-  integrity sha512-707uiuReSt+nAx6d0c21xLjLm2lxeKc7padxjv92CIrIocnQSlJPxSCM7r5zBhwiahJA6MNQwmTl2xznU67KgA==
-  dependencies:
-    "@aws-crypto/sha256-browser" "5.2.0"
-    "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/client-sso-oidc" "3.621.0"
-    "@aws-sdk/core" "3.621.0"
-    "@aws-sdk/credential-provider-node" "3.621.0"
-    "@aws-sdk/middleware-host-header" "3.620.0"
-    "@aws-sdk/middleware-logger" "3.609.0"
-    "@aws-sdk/middleware-recursion-detection" "3.620.0"
-    "@aws-sdk/middleware-user-agent" "3.620.0"
-    "@aws-sdk/region-config-resolver" "3.614.0"
-    "@aws-sdk/types" "3.609.0"
-    "@aws-sdk/util-endpoints" "3.614.0"
-    "@aws-sdk/util-user-agent-browser" "3.609.0"
-    "@aws-sdk/util-user-agent-node" "3.614.0"
-    "@smithy/config-resolver" "^3.0.5"
-    "@smithy/core" "^2.3.1"
-    "@smithy/fetch-http-handler" "^3.2.4"
-    "@smithy/hash-node" "^3.0.3"
-    "@smithy/invalid-dependency" "^3.0.3"
-    "@smithy/middleware-content-length" "^3.0.5"
-    "@smithy/middleware-endpoint" "^3.1.0"
-    "@smithy/middleware-retry" "^3.0.13"
-    "@smithy/middleware-serde" "^3.0.3"
-    "@smithy/middleware-stack" "^3.0.3"
-    "@smithy/node-config-provider" "^3.1.4"
-    "@smithy/node-http-handler" "^3.1.4"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/smithy-client" "^3.1.11"
-    "@smithy/types" "^3.3.0"
-    "@smithy/url-parser" "^3.0.3"
-    "@smithy/util-base64" "^3.0.0"
-    "@smithy/util-body-length-browser" "^3.0.0"
-    "@smithy/util-body-length-node" "^3.0.0"
-    "@smithy/util-defaults-mode-browser" "^3.0.13"
-    "@smithy/util-defaults-mode-node" "^3.0.13"
-    "@smithy/util-endpoints" "^2.0.5"
-    "@smithy/util-middleware" "^3.0.3"
-    "@smithy/util-retry" "^3.0.3"
-    "@smithy/util-utf8" "^3.0.0"
-    tslib "^2.6.2"
-
-"@aws-sdk/core@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.621.0.tgz#e38c56c3ce0c819ca1185eaabcb98412429aaca3"
-  integrity sha512-CtOwWmDdEiINkGXD93iGfXjN0WmCp9l45cDWHHGa8lRgEDyhuL7bwd/pH5aSzj0j8SiQBG2k0S7DHbd5RaqvbQ==
-  dependencies:
-    "@smithy/core" "^2.3.1"
-    "@smithy/node-config-provider" "^3.1.4"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/signature-v4" "^4.1.0"
-    "@smithy/smithy-client" "^3.1.11"
-    "@smithy/types" "^3.3.0"
-    "@smithy/util-middleware" "^3.0.3"
+    "@aws-sdk/types" "3.821.0"
+    "@aws-sdk/xml-builder" "3.821.0"
+    "@smithy/core" "^3.5.1"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/signature-v4" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.1"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-utf8" "^4.0.0"
     fast-xml-parser "4.4.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-env@3.620.1":
-  version "3.620.1"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz#d4692c49a65ebc11dae3f7f8b053fee9268a953c"
-  integrity sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==
+"@aws-sdk/credential-provider-env@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.823.0.tgz#93a63a5800b4ba7d8ece3421e6e7f3ee4ca44759"
+  integrity sha512-AIrLLwumObge+U1klN4j5ToIozI+gE9NosENRyHe0GIIZgTLOG/8jxrMFVYFeNHs7RUtjDTxxewislhFyGxJ/w==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-http@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz#5f944bf548f203d842cf71a5792f73c205544627"
-  integrity sha512-/jc2tEsdkT1QQAI5Dvoci50DbSxtJrevemwFsm0B73pwCcOQZ5ZwwSdVqGsPutzYzUVx3bcXg3LRL7jLACqRIg==
+"@aws-sdk/credential-provider-http@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.823.0.tgz#08c6c4e4656088d78dae9b6e74d5adf332d289c5"
+  integrity sha512-u4DXvB/J/o2bcvP1JP6n3ch7V3/NngmiJFPsM0hKUyRlLuWM37HEDEdjPRs3/uL/soTxrEhWKTA9//YVkvzI0w==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/fetch-http-handler" "^3.2.4"
-    "@smithy/node-http-handler" "^3.1.4"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/smithy-client" "^3.1.11"
-    "@smithy/types" "^3.3.0"
-    "@smithy/util-stream" "^3.1.3"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/fetch-http-handler" "^5.0.4"
+    "@smithy/node-http-handler" "^4.0.6"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.1"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-stream" "^4.2.2"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-ini@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.621.0.tgz#bda2365f88fee40e3ae067b08bf484106c339222"
-  integrity sha512-0EWVnSc+JQn5HLnF5Xv405M8n4zfdx9gyGdpnCmAmFqEDHA8LmBdxJdpUk1Ovp/I5oPANhjojxabIW5f1uU0RA==
+"@aws-sdk/credential-provider-ini@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.823.0.tgz#babc5f8e707e456b92433126e9101b1bdf840c1f"
+  integrity sha512-C0o63qviK5yFvjH9zKWAnCUBkssJoQ1A1XAHe0IAQkurzoNBSmu9oVemqwnKKHA4H6QrmusaEERfL00yohIkJA==
   dependencies:
-    "@aws-sdk/credential-provider-env" "3.620.1"
-    "@aws-sdk/credential-provider-http" "3.621.0"
-    "@aws-sdk/credential-provider-process" "3.620.1"
-    "@aws-sdk/credential-provider-sso" "3.621.0"
-    "@aws-sdk/credential-provider-web-identity" "3.621.0"
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/credential-provider-imds" "^3.2.0"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/shared-ini-file-loader" "^3.1.4"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/credential-provider-env" "3.823.0"
+    "@aws-sdk/credential-provider-http" "3.823.0"
+    "@aws-sdk/credential-provider-process" "3.823.0"
+    "@aws-sdk/credential-provider-sso" "3.823.0"
+    "@aws-sdk/credential-provider-web-identity" "3.823.0"
+    "@aws-sdk/nested-clients" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/credential-provider-imds" "^4.0.6"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-node@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.621.0.tgz#9cc5052760a9f9d70d70f12ddbdbf0d59bf13a47"
-  integrity sha512-4JqpccUgz5Snanpt2+53hbOBbJQrSFq7E1sAAbgY6BKVQUsW5qyXqnjvSF32kDeKa5JpBl3bBWLZl04IadcPHw==
+"@aws-sdk/credential-provider-node@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.823.0.tgz#11e6e11a44d32a0526f767a1b809fa8cf5df70f9"
+  integrity sha512-nfSxXVuZ+2GJDpVFlflNfh55Yb4BtDsXLGNssXF5YU6UgSPsi8j2YkaE92Jv2s7dlUK07l0vRpLyPuXMaGeiRQ==
   dependencies:
-    "@aws-sdk/credential-provider-env" "3.620.1"
-    "@aws-sdk/credential-provider-http" "3.621.0"
-    "@aws-sdk/credential-provider-ini" "3.621.0"
-    "@aws-sdk/credential-provider-process" "3.620.1"
-    "@aws-sdk/credential-provider-sso" "3.621.0"
-    "@aws-sdk/credential-provider-web-identity" "3.621.0"
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/credential-provider-imds" "^3.2.0"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/shared-ini-file-loader" "^3.1.4"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/credential-provider-env" "3.823.0"
+    "@aws-sdk/credential-provider-http" "3.823.0"
+    "@aws-sdk/credential-provider-ini" "3.823.0"
+    "@aws-sdk/credential-provider-process" "3.823.0"
+    "@aws-sdk/credential-provider-sso" "3.823.0"
+    "@aws-sdk/credential-provider-web-identity" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/credential-provider-imds" "^4.0.6"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-process@3.620.1":
-  version "3.620.1"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz#10387cf85400420bb4bbda9cc56937dcc6d6d0ee"
-  integrity sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==
+"@aws-sdk/credential-provider-process@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.823.0.tgz#10a70eb47c7196056a4f846741e7df1851c1352f"
+  integrity sha512-U/A10/7zu2FbMFFVpIw95y0TZf+oYyrhZTBn9eL8zgWcrYRqxrxdqtPj/zMrfIfyIvQUhuJSENN4dx4tfpCMWQ==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/shared-ini-file-loader" "^3.1.4"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-sso@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz#710f413708cb372f9f94e8eb9726cf263ffd83e3"
-  integrity sha512-Kza0jcFeA/GEL6xJlzR2KFf1PfZKMFnxfGzJzl5yN7EjoGdMijl34KaRyVnfRjnCWcsUpBWKNIDk9WZVMY9yiw==
+"@aws-sdk/credential-provider-sso@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.823.0.tgz#82d3811bfcb3b688c50e48e4a0d76c2adde393ca"
+  integrity sha512-ff8IM80Wqz1V7VVMaMUqO2iR417jggfGWLPl8j2l7uCgwpEyop1ZZl5CFVYEwSupRBtwp+VlW1gTCk7ke56MUw==
   dependencies:
-    "@aws-sdk/client-sso" "3.621.0"
-    "@aws-sdk/token-providers" "3.614.0"
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/shared-ini-file-loader" "^3.1.4"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/client-sso" "3.823.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/token-providers" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-web-identity@3.621.0":
-  version "3.621.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz#b25878c0a05dad60cd5f91e7e5a31a145c2f14be"
-  integrity sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==
+"@aws-sdk/credential-provider-web-identity@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.823.0.tgz#eeee9df242abdda5b873277a65517fd67c67d0a2"
+  integrity sha512-lzoZdJMQq9w7i4lXVka30cVBe/dZoUDZST8Xz/soEd73gg7RTKgG+0szL4xFWgdBDgcJDWLfZfJzlbyIVyAyOA==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/nested-clients" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-host-header@3.620.0":
-  version "3.620.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz#b561d419a08a984ba364c193376b482ff5224d74"
-  integrity sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==
+"@aws-sdk/eventstream-handler-node@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.821.0.tgz#c93dae50b173f76889526336c6528b53cb58ac1a"
+  integrity sha512-JqmzOCAnd9pUnmbrqXIbyBUxjw/UAfXAu8KAsE/4SveUIvyYRbYSTfCoPq6nnNJQpBtdEFLkjvBnHKBcInDwkg==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/eventstream-codec" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-logger@3.609.0":
-  version "3.609.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz#ed44d201f091b8bac908cbf14724c7a4d492553f"
-  integrity sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==
+"@aws-sdk/middleware-eventstream@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.821.0.tgz#fdaba4c2434b53a0d9b5886f5cabc25d8b19bd5d"
+  integrity sha512-L+qud1uX1hX7MpRy564dFj4/5sDRKVLToiydvgRy6Rc3pwsVhRpm6/2djMVgDsFI3sYd+JoeTFjEypkoV3LE5Q==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-recursion-detection@3.620.0":
-  version "3.620.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz#f8270dfff843fd756be971e5673f89c6a24c6513"
-  integrity sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==
+"@aws-sdk/middleware-host-header@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz#1dfda8da4e0f9499648dab9a989d10706e289cc7"
+  integrity sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-user-agent@3.620.0":
-  version "3.620.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz#1fe3104f04f576a942cf0469bfbd73c38eef3d9e"
-  integrity sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==
+"@aws-sdk/middleware-logger@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz#87067907a25cdc6c155d3a35fe32e399c1ef87e6"
+  integrity sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@aws-sdk/util-endpoints" "3.614.0"
-    "@smithy/protocol-http" "^4.1.0"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/region-config-resolver@3.614.0":
-  version "3.614.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz#9cebb31a5bcfea2a41891fff7f28d0164cde179a"
-  integrity sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==
+"@aws-sdk/middleware-recursion-detection@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz#bc34b08efc1e1af7b14a58023a79bfb75a0b64fa"
+  integrity sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/node-config-provider" "^3.1.4"
-    "@smithy/types" "^3.3.0"
-    "@smithy/util-config-provider" "^3.0.0"
-    "@smithy/util-middleware" "^3.0.3"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/token-providers@3.614.0":
-  version "3.614.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz#88da04f6d4ce916b0b0f6e045676d04201fb47fd"
-  integrity sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==
+"@aws-sdk/middleware-user-agent@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.823.0.tgz#c92005b02f12afe1c1ffd30a24c973e545e9f4e3"
+  integrity sha512-TKRQK09ld1LrIPExC9rIDpqnMsWcv+eq8ABKFHVo8mDLTSuWx/IiQ4eCh9T5zDuEZcLY4nNYCSzXKqw6XKcMCA==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/property-provider" "^3.1.3"
-    "@smithy/shared-ini-file-loader" "^3.1.4"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@aws-sdk/util-endpoints" "3.821.0"
+    "@smithy/core" "^3.5.1"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@aws-sdk/types@3.609.0":
-  version "3.609.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.609.0.tgz#06b39d799c9f197a7b43670243e8e78a3bf7d6a5"
-  integrity sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==
+"@aws-sdk/nested-clients@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.823.0.tgz#c49eb5d99df805486d67c44ee872a8bbe4300f94"
+  integrity sha512-/BcyOBubrJnd2gxlbbmNJR1w0Z3OVN/UE8Yz20e+ou+Mijjv7EbtVwmWvio1e3ZjphwdA8tVfPYZKwXmrvHKmQ==
   dependencies:
-    "@smithy/types" "^3.3.0"
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/middleware-host-header" "3.821.0"
+    "@aws-sdk/middleware-logger" "3.821.0"
+    "@aws-sdk/middleware-recursion-detection" "3.821.0"
+    "@aws-sdk/middleware-user-agent" "3.823.0"
+    "@aws-sdk/region-config-resolver" "3.821.0"
+    "@aws-sdk/types" "3.821.0"
+    "@aws-sdk/util-endpoints" "3.821.0"
+    "@aws-sdk/util-user-agent-browser" "3.821.0"
+    "@aws-sdk/util-user-agent-node" "3.823.0"
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/core" "^3.5.1"
+    "@smithy/fetch-http-handler" "^5.0.4"
+    "@smithy/hash-node" "^4.0.4"
+    "@smithy/invalid-dependency" "^4.0.4"
+    "@smithy/middleware-content-length" "^4.0.4"
+    "@smithy/middleware-endpoint" "^4.1.9"
+    "@smithy/middleware-retry" "^4.1.10"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/node-http-handler" "^4.0.6"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.1"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.17"
+    "@smithy/util-defaults-mode-node" "^4.0.17"
+    "@smithy/util-endpoints" "^3.0.6"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.5"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz#2f1cd54ca140cbdc821a604d8b20444f9b0b77cf"
+  integrity sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==
+  dependencies:
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.823.0.tgz#820dd7dace5f7b995ed5b2b10c6ca881b14712a3"
+  integrity sha512-vz6onCb/+g4y+owxGGPMEMdN789dTfBOgz/c9pFv0f01840w9Rrt46l+gjQlnXnx+0KG6wNeBIVhFdbCfV3HyQ==
+  dependencies:
+    "@aws-sdk/core" "3.823.0"
+    "@aws-sdk/nested-clients" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.821.0.tgz#edfd4595208e4e9f24f397fbc8cb82e3ec336649"
+  integrity sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==
+  dependencies:
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
 "@aws-sdk/types@^3.222.0":
@@ -436,14 +429,14 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/util-endpoints@3.614.0":
-  version "3.614.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz#6564b0ffd7dc3728221e9f9821f5aab1cc58468e"
-  integrity sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==
+"@aws-sdk/util-endpoints@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.821.0.tgz#8883370bc3218e532fb9b7358e23369dc0a77201"
+  integrity sha512-Uknt/zUZnLE76zaAAPEayOeF5/4IZ2puTFXvcSCWHsi9m3tqbb9UozlnlVqvCZLCRWfQryZQoG2W4XSS3qgk5A==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/types" "^3.3.0"
-    "@smithy/util-endpoints" "^2.0.5"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-endpoints" "^3.0.6"
     tslib "^2.6.2"
 
 "@aws-sdk/util-locate-window@^3.0.0":
@@ -453,24 +446,33 @@
   dependencies:
     tslib "^2.6.2"
 
-"@aws-sdk/util-user-agent-browser@3.609.0":
-  version "3.609.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz#aa15421b2e32ae8bc589dac2bd6e8969832ce588"
-  integrity sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==
+"@aws-sdk/util-user-agent-browser@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz#32962fd3ae20986da128944b88a231508e017f5b"
+  integrity sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/types" "^4.3.1"
     bowser "^2.11.0"
     tslib "^2.6.2"
 
-"@aws-sdk/util-user-agent-node@3.614.0":
-  version "3.614.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz#1e3f49a80f841a3f21647baed2adce01aac5beb5"
-  integrity sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==
+"@aws-sdk/util-user-agent-node@3.823.0":
+  version "3.823.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.823.0.tgz#24b3d2671f079be5224997da0d7a2707a8bc21d0"
+  integrity sha512-WvNeRz7HV3JLBVGTXW4Qr5QvvWY0vtggH5jW/NqHFH+ZEliVQaUIJ/HNLMpMoCSiu/DlpQAyAjRZXAptJ0oqbw==
   dependencies:
-    "@aws-sdk/types" "3.609.0"
-    "@smithy/node-config-provider" "^3.1.4"
-    "@smithy/types" "^3.3.0"
+    "@aws-sdk/middleware-user-agent" "3.823.0"
+    "@aws-sdk/types" "3.821.0"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@3.821.0":
+  version "3.821.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz#ff89bf1276fca41276ed508b9c8ae21978d91177"
+  integrity sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==
+  dependencies:
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.27.1":
@@ -664,227 +666,227 @@
     url-parse "1.5.10"
     uuid "^9.0.1"
 
-"@ckeditor/ckeditor5-adapter-ckfinder@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-45.1.0.tgz#6bd04f2f630d63f1dfe12d2038cddab7d2139ccc"
-  integrity sha512-otNU8VFFxKxRJH3t7u1C74BEq615EamHN7B/W+grpVszLqYoEvAZ3A2t1Q+OSg8+SIiTgpYsp8s5QqjWYB/72A==
+"@ckeditor/ckeditor5-adapter-ckfinder@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-46.0.0-alpha.0.tgz#4a04f5da5c13df763b1903bacd7a8cc76e44d40f"
+  integrity sha512-lUX9ovZcNYVNYJlylTno8dOuHcWO0sOnuAq3ZMp9/XcvEbNqws9O53LP95A2lmxldvZpZL4tt//7KpmJggjQgg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-upload" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-upload" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-ai@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ai/-/ckeditor5-ai-45.1.0.tgz#5c5d70cf056dc38d33e07e59e96937476fbbfd5d"
-  integrity sha512-pp2F5x9vIYTMhwALgh6WnH3Iv/FCRF84Ce35A8YTC4Pz+tIhHlpouNZYHCCUfV+tsjnXzSj3kobyIUTn5vKATg==
+"@ckeditor/ckeditor5-ai@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ai/-/ckeditor5-ai-46.0.0-alpha.0.tgz#0c4f9c6674d1228795d09836e516270e8783ad2a"
+  integrity sha512-s9rkoEecvGyldgEVmPpaj/6q3EXqBy901/f2Axb+235rN4SI0wnGRmfILsH+OxnuFZcnejxSY0vzne9lHax3Ng==
   dependencies:
-    "@aws-sdk/client-bedrock-runtime" "3.621.0"
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-table" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@aws-sdk/client-bedrock-runtime" "3.823.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-table" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-alignment@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-45.1.0.tgz#b2a233839af8b5713c85982b610bed895b7f408d"
-  integrity sha512-wRmR7ljy2t8w9Kv7WTHkQZnp6knK63C9LncwMARkmaTiUBU9QLrH0+M4DXRyv6uNdkGZ4WGtLurrtTBnIQcVUw==
+"@ckeditor/ckeditor5-alignment@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-46.0.0-alpha.0.tgz#1cdc965b140301adcfff9bca9e028b1677adc324"
+  integrity sha512-LB1BSqr9y3uaJu9gvoCad5ATq9RbwEX8EXWCc01oCGMClCm3z+ho8mwNFAtj87ELjS/hMiXEF/kRUwbmFvXq8A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-autoformat@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-45.1.0.tgz#b14f7fdb11a8d0bba18c591a29e4edaf533b214a"
-  integrity sha512-jdV2ot42GVFcoL2HOqUdxPCj/Cz8SjDBl6N/PAkwaHr7AjPOr78c/4WeGNA8a1rXxy+a1GcEKfQff1wq8xHOfg==
+"@ckeditor/ckeditor5-autoformat@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-46.0.0-alpha.0.tgz#fd69c15dc9a139e4ac6e639256b9c412f6573f58"
+  integrity sha512-z0Do1oZxR0eZSzIc8LZbFb9Q8TsCXPwVUOtrEnHpJsm7IRMbi1L5oCtvNXsGMcxXaxHx5hRv0qbKXY92c7AKtw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-heading" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-heading" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-autosave@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-45.1.0.tgz#b6e3882e3c9f89212770b902f74f21ce3c08b80f"
-  integrity sha512-FsMLxlDxxFxBDFFboCxqIPC+xFsOknqB9PpIE7il2sAfrNWZAtpdtQ73v8YqJwRlLwbPcY69ZaZapznl590lBg==
+"@ckeditor/ckeditor5-autosave@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-46.0.0-alpha.0.tgz#da1333f09ed92b3b4fe8a19220d6d461b4479011"
+  integrity sha512-u9ARl6dkIlIXtDd0NM23nZwieEAcu/x4AH+PUnLh5rN6tnhj/iC4qCTNJIfddHsKnmeshm5pWC3h+Z2zoqN2qA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-basic-styles@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-45.1.0.tgz#edc24a553a0ef401ea83c3be3acf11ea882a161c"
-  integrity sha512-aykdivtT5NgiQdgTqKlhbmffZuMG6vxEE+/XsmKfyi5mJ6oh9lv50zb0bze7sQvBhynt5CC8tKUI4O4VC3a5dw==
+"@ckeditor/ckeditor5-basic-styles@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-46.0.0-alpha.0.tgz#d2d8b75a0d2390f96792cbc661022221741252f5"
+  integrity sha512-SnO0YHWqjRZ/mQn27kpUqmS+hmZ8LUbm0OIWIS6C8eHjAXRDB1URNH06HOnzcMem9xKxpYjWpgkMUiO8snN5kg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-block-quote@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-45.1.0.tgz#1cb12a29940246becfdd623f1d76a0b77c3351ba"
-  integrity sha512-zsZyuh6w1H/TV2QvJnZ6mScvYMNn6itnFbbTHJWAJoLQTs2XjiUaVy7m+pK81x0VHrH1HPsj/ErccscrHOQTdQ==
+"@ckeditor/ckeditor5-block-quote@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-46.0.0-alpha.0.tgz#a0f1b67a0fe81fdd34382ff96f0771437f6773e1"
+  integrity sha512-lep89Pir9F+lboPwxYH3p+pyC6GIe4TbzP6+vWm0uBrlWGuGHvD9qmImTOmhLZydeUc+Qkx41hO3sv578LT5AA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-bookmark@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-45.1.0.tgz#28a3c336ab196c6f9f357bea1c5414517eea3744"
-  integrity sha512-UtdpprqMuoEstxH0JZIGzyRFqo2gpiiLP/4HozV3ygV2buonigbJgx0fDJvHqTmkcSzXIG7+FUACcXnyVvsDXA==
+"@ckeditor/ckeditor5-bookmark@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-46.0.0-alpha.0.tgz#c4bf577ef6ed9277a0659d00348835d8fc5bc5da"
+  integrity sha512-Du/MiZlPlVAUI/OxTnPAxxZg4nJ8d/dZTmt0uhhiO9ANl/qb9sZErZCVrZkP2bxxqJyKb40mysm84OML9zVq2g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-link" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-link" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-case-change@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-case-change/-/ckeditor5-case-change-45.1.0.tgz#5b17ee4bd22b89e1a7b1d65f9699903796372c02"
-  integrity sha512-7EVgbTN7elhjs9vMmLXIiTuWcLdxx+1zoifyuI0niqhRYh6KDj7GaW5u1cCV+A/3Iyx7n2GAeoBN05uEAG3QzA==
+"@ckeditor/ckeditor5-case-change@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-case-change/-/ckeditor5-case-change-46.0.0-alpha.0.tgz#2d2bb365614fc7dcef60267d50c58849409aa334"
+  integrity sha512-MHBl/0hpjBQcRBi7qiVkFqtJoMLoWDpWD9b80zkb/G/v0KvPt1xVl93DsV9zcHIm16rmgYxc6pXUHOYZUZivPQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-ckbox@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-45.1.0.tgz#938f87e65c827899219de4eabc1218d03a8b4ca5"
-  integrity sha512-MjZl4R2AXTX+wKGIVAyifzNOJAFUfmdnaQ0j6f25Ezka2V83iY2Zxjt1fuu52OJWAcuiL4WEupZ0F75BN3Lm9w==
+"@ckeditor/ckeditor5-ckbox@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-46.0.0-alpha.0.tgz#624a8cd236bb508696664d079c486b0779fff8fb"
+  integrity sha512-B9dXs+SloLkjonccYnFOglLnep4AtdUzuAphMJNoEOQnytrRQzVPiQqXHXDqQqtMX5wEwXIIQbyP2L523Y6Pxg==
   dependencies:
-    "@ckeditor/ckeditor5-cloud-services" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-upload" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-cloud-services" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-upload" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
     blurhash "2.0.5"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-ckfinder@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-45.1.0.tgz#092260192abc81fdbb77c4c88b2d06863a412b21"
-  integrity sha512-iOcz/z8W+sd0Kf4L7R6U16CC2GYDeujrQbtlGEg9gF1REJAeTZBxsK9LAcLSOHF7KjaJSykH1GJpzo2Kzp2lKg==
+"@ckeditor/ckeditor5-ckfinder@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-46.0.0-alpha.0.tgz#ec661b522026738a5959e90c275261addf018bcc"
+  integrity sha512-527TjqoV9fGvSul28c2q0pK5ZA4Pf7MDCCYevvpeSM0pvd4rCUciUnUPJRHaBjF3tnLUk20W5gmQ7ltFcdUpEg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-clipboard@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-45.1.0.tgz#0106a78eb099937f5c78d64595ad9ec6c8beae32"
-  integrity sha512-+78bGL0OQPs3n1OTSssnfEvYLSuCNLkGL2c/7IdDtBi3EWVt5CAr8edb6DMSWDfnlCHCsSm6pUQF8GeTPhQLHg==
+"@ckeditor/ckeditor5-clipboard@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-46.0.0-alpha.0.tgz#f2785b805b945b1b5f8364445ab78e75103be6d6"
+  integrity sha512-Zp1dOyro3rwO1TbHJ8+FI4kki6aHWtvJHOZnCiu9LDfAPHoN6Td+PeYy9a1KQnQ2ylE6VzfEhNyZUCm+mbMRBQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-cloud-services@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-45.1.0.tgz#42d61130de0a4524dc1d58727788b134c7043cbe"
-  integrity sha512-dyJ+TaaZQwO33GF6bmMpPRnRttwmrWZH9GCHhVH1LiPPyDr0GnU0YPbwzdhStW1Q9PVvqtgQJAyosvQ4y8qiqQ==
+"@ckeditor/ckeditor5-cloud-services@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-46.0.0-alpha.0.tgz#e1e086b78ab9a6420c0848a116fb034531c2ec75"
+  integrity sha512-b+16KQYnsvll9RJELjMJgpbXkmFvBfPRixjpNk+qaOi6poLGxE6x+TIRujoGH5VZjBb0ySSeH9+NAejOLIBbvA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-code-block@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-45.1.0.tgz#3eaac941f97e53a991993937251937f44a56f3a8"
-  integrity sha512-M+WJRmQvbYrj6Vm7p2he0pj4vgAFTqAoWB9aNRDR4JPTOM2ZTYhpk7vVBZpYNbbmaSP+opJIjnw86MEcgFtRFg==
+"@ckeditor/ckeditor5-code-block@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-46.0.0-alpha.0.tgz#377ae8626decc6096b8e13c51af4bbd215a2c86c"
+  integrity sha512-p6i6+1pCD8q3+VCqkC4jMy7U/OP+lwQtrAlsXxKNdgU3eTgIWWBQcQ6PRzmPX1dQDtoDBb0J1pxABcjVdesuaQ==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-collaboration-core@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-collaboration-core/-/ckeditor5-collaboration-core-45.1.0.tgz#7c91d992e28280e067fc473e7bc0151f076f1c26"
-  integrity sha512-jHvObDHY+HJwhGdRMOLcZF3ui92lySPYyn/Mt01+oJ5SaHaS4kxupIBkL6nBVcknBFBi3u6QeZGtaDApzPnK+A==
+"@ckeditor/ckeditor5-collaboration-core@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-collaboration-core/-/ckeditor5-collaboration-core-46.0.0-alpha.0.tgz#b20a0ebb31764578f8eb98971e0c1c99660ed29e"
+  integrity sha512-4ODuaTDqPNg3lVrlIxhLYnhEKCc0F8MiFfpUyJYJ/o6pHf/1yV8xi5jYWccWKN3NjeO8ODXxCqhbQl3lyoODVw==
   dependencies:
-    "@ckeditor/ckeditor5-comments" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-track-changes" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@types/luxon" "3.4.2"
-    ckeditor5 "45.1.0"
-    luxon "3.5.0"
+    "@ckeditor/ckeditor5-comments" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-track-changes" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@types/luxon" "3.6.2"
+    ckeditor5 "46.0.0-alpha.0"
+    luxon "3.6.1"
 
-"@ckeditor/ckeditor5-comments@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-comments/-/ckeditor5-comments-45.1.0.tgz#e6175d5c6398ec1f8d6ecee44434c91a4ca6bf00"
-  integrity sha512-4sr4Hmzy0KErezzvmyFV/s4kQEcq+j0QRPjj2OfEMKzq/h/XZ9RKkYnYmJqvNCnmrn5HR3OV61x0SmOVJBdOwg==
+"@ckeditor/ckeditor5-comments@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-comments/-/ckeditor5-comments-46.0.0-alpha.0.tgz#5eded14d0401651e952350c4b006da2cb2700e3c"
+  integrity sha512-bpVUMSDudeMltkZyp4Q8nNNqM0a6TZQdimZ1JgBjxZNGYd45mikrbbsHNAyrLW5Mgz3saqN1xg6dk9vXG7HCbw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-collaboration-core" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-paragraph" "45.1.0"
-    "@ckeditor/ckeditor5-select-all" "45.1.0"
-    "@ckeditor/ckeditor5-source-editing" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-undo" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    ckeditor5-collaboration "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-collaboration-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-paragraph" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-select-all" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-source-editing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-undo" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    ckeditor5-collaboration "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-core@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-45.1.0.tgz#611a94e8cec8ba197d8c0dce1688e627c57bd04c"
-  integrity sha512-rpJIkorFOMpHwhDjaRPpqI3NB4O44Vab/HH6KAnTTc3ZUoUzUL7+NlBweb5AHzOcmluXneQQrGQXB7J9bJqrBQ==
+"@ckeditor/ckeditor5-core@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.0-alpha.0.tgz#05c77eb683f921e379735f042f3c5eac018df6c3"
+  integrity sha512-co3wWcdBMezNGXs1h+rQJ1T6c2zJafiSpwFu53qrjPswQ2+3KatrGNRwbtajgs+oTFi1yjqc9f8VKkMG7EGF/w==
   dependencies:
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-watchdog" "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-watchdog" "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
 "@ckeditor/ckeditor5-dev-bump-year@^49.0.0":
   version "49.0.2"
@@ -974,883 +976,907 @@
     terser-webpack-plugin "^5.0.0"
     through2 "^4.0.0"
 
-"@ckeditor/ckeditor5-document-outline@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-document-outline/-/ckeditor5-document-outline-45.1.0.tgz#47c7bf8fd0887976975ce6393bc8a02b7b36df6a"
-  integrity sha512-tkYtwFnWtdOyp2gdvLbHn/2AwAcjKGC7RgaI8D4xDWowUKCV7lpKcdQOr8A3bJjVI8hwPrJD9Fl5vxYCJxusdg==
+"@ckeditor/ckeditor5-document-outline@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-document-outline/-/ckeditor5-document-outline-46.0.0-alpha.0.tgz#d95520c6a30a10146e4c7d12ddecdb1543cd80a9"
+  integrity sha512-SXywOe5YoKqSQpWJn7qt9IJT/dzbVyzHBBPCTFOQsHgj712laxxIMp3gU7QrbOW0pzZDxtH3jDi4Gk+sxCboiA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-heading" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-heading" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-easy-image@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-45.1.0.tgz#e991467db9e8bc453d8ba6fb4ad062173e353f10"
-  integrity sha512-NyJ0ZilpFQKFGa6KFYlQpIrZpZvKnunuz/moTCOwh3E4yb84Wug6Nk+UWyvHXX7/olU9sgZevWFS9vLKb/yLfA==
+"@ckeditor/ckeditor5-easy-image@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-46.0.0-alpha.0.tgz#0095677c0120d8918323c998515b11c57fbc9471"
+  integrity sha512-+Ew1YeDR6AlQBpirVcjBSSYU1FQ/xJfZOVgb3E5rUm75XDjhY0s25KCmT+T2cY1182tTMjWjIRkBRlgiMF6weA==
   dependencies:
-    "@ckeditor/ckeditor5-cloud-services" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-upload" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-cloud-services" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-upload" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-editor-balloon@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-45.1.0.tgz#ddaecec2b944e0ccbf0d545a996d1f80a9b68de7"
-  integrity sha512-DNHGX2W16kmT/Y7YG4nSSqBOrEhArC975dlYqGTSBc6HUIB6PTZPbzu5qdFUJ+vziXbtw4YdnqtZCuQHswXypg==
+"@ckeditor/ckeditor5-editor-balloon@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-46.0.0-alpha.0.tgz#5677b9f039dd6410465818deabeb08a2993e5f8d"
+  integrity sha512-5bcufePJECCWMixBBtphwet3jm31607xccp2XmemhlSOL1HlZ10p0t0hoWHFtJEBzOXH6jO0sPF+mxt0MvgqXw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-classic@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-45.1.0.tgz#d0a32949c6345abd3aee32dbad3a28c9beae6977"
-  integrity sha512-ZIa6PPMPl4dawjcG4mTZy8SnHaS4kNOybPJDEIziWh+LLlTDnHlwXRZqjOqdLyWR2b9yrrZKnOrVdWIaOGs29Q==
+"@ckeditor/ckeditor5-editor-classic@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-46.0.0-alpha.0.tgz#c5061cca6fc0ab4013953bce448cd43fc7625ad3"
+  integrity sha512-tVCRtO15UNVW8CvYhGLgeSVFnxS3QbnzArryBBBkZicx7GYGmiZ6CD0HuhBJ555TRrn81W6OpikKjgymE0OTLw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-decoupled@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-45.1.0.tgz#2e5c2abf6376f2813c9079f802d64121dc847885"
-  integrity sha512-wAfN1k+wVSaOMcDdTTdViHWqTzXulB6MEMNFceO7KjwmTqJwHGnVjMQRH5Z27oKnJltBvs+kW9Bl/AH2UcuBLg==
+"@ckeditor/ckeditor5-editor-decoupled@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-46.0.0-alpha.0.tgz#41524353d82c4ed05037bd5c95414ee52146554e"
+  integrity sha512-LdsnGmljUCBS5ur3+NwIonjX8waZO3pgwKVendV8K/tNf6U1+WnUsOBmRvIPpO1Z0i5l0wkQ/P7Mz0d/zH4OHA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-inline@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-45.1.0.tgz#89255d18877c6ea5c8df7607cba73e3587919a60"
-  integrity sha512-KQvZ0ObX7Y5AJvfkagaQ7S0eVCF2zHENjENaYraAh5OoaeNTWReh/w57UiijH9dTfE6JEzqDjaXYepyIhmNOYg==
+"@ckeditor/ckeditor5-editor-inline@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-46.0.0-alpha.0.tgz#e371dab2de12cec55533a5997752dddddd83b3be"
+  integrity sha512-WvfZlaiSZ6lMlaEAf2LpkArIL+eAky9WMyhDX6J4dMZBDtvAI69nr8WWeTBlrWaEnnTVpq306AStVBKi69ocVg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-multi-root@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-45.1.0.tgz#f4ca0875e88bed0502c9954e4867bc8b962a8513"
-  integrity sha512-1arT2NWuzQduDz4OpTr1cc4iS4S036No9YfaJFoUmCMtpZMQck0MyD6dnjXOUoALi9qpVhMtxPsUU8lvEP1Ynw==
+"@ckeditor/ckeditor5-editor-multi-root@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-46.0.0-alpha.0.tgz#1033776532b0359fb5a1159997d9267e44d70c33"
+  integrity sha512-RexybAXG6es1/+nVHOSjoSneKDR+0U7r814xjkOzvwOEsVqlK9OIdMGjeIvUCfFLwPvORBwyGuEqpkz8TBIizg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-email@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-email/-/ckeditor5-email-45.1.0.tgz#0bb8e35558c71939c74f5fbc8891fa73c3f96aa7"
-  integrity sha512-L0PCEeUOyLliDejKjFZI+VlzBx+y+DFqnEx/O6QjZgw8YpjMe5Np9C778q5iermG4O9SnMoIUSgamRCN/OWmag==
+"@ckeditor/ckeditor5-email@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-email/-/ckeditor5-email-46.0.0-alpha.0.tgz#8cb3d5545eb16c887424f239934a24feac2b2888"
+  integrity sha512-y+3L2boyT4SOjNqB8f9OK0tK3uvQTC/qDzGir4A7f04aeaQMTh8pZzD/5xxI2A09Ik/l0003wNIOl8czfIeHWQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-export-inline-styles" "45.1.0"
-    "@ckeditor/ckeditor5-font" "45.1.0"
-    "@ckeditor/ckeditor5-html-support" "45.1.0"
-    "@ckeditor/ckeditor5-list" "45.1.0"
-    "@ckeditor/ckeditor5-table" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-export-inline-styles" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-font" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-html-support" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-table" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-emoji@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-45.1.0.tgz#3b53cc2b4d7b2aa7b7d76e6e620418d6aff73667"
-  integrity sha512-KtUpD/1XBt7oi0NdkQrZxCd/cvc+XFFcZVZfwpz+3O7ypBcJORJpTn+9x/7Vxo/6iyFoI4XBfMVR/4jTFYgzIg==
+"@ckeditor/ckeditor5-emoji@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-46.0.0-alpha.0.tgz#363996b6fd7b9466fff21d5141a524c3bb59d1b5"
+  integrity sha512-RdhMi3mYXqYKcy3LIFEBtNoVJJbDjD3K1Q+kzOYbJfdEFS2NZGzqana1OPZE3w+tKGdWHD0Lk1Tk5B4oG2+jqw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-mention" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-mention" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
     fuzzysort "3.1.0"
 
-"@ckeditor/ckeditor5-engine@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-45.1.0.tgz#b71011901599a91bd96d544aaa81f2fc0e773658"
-  integrity sha512-3O1fsxi1wGQBz60vtKgSFNPSzU+R2jxUXDPDPhm88oCpqU5l5Giz+bcM7AVQg6b8wc8caVu5dVeR4/U9JsqGmQ==
+"@ckeditor/ckeditor5-engine@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.0-alpha.0.tgz#ec908694a9a6b52448a566bf11f50758979e36a5"
+  integrity sha512-I3JGLYiVK6T38I5BHo487mZXMYRh8Va9jNeRagGjyXm1zPHw4EAAMh/FqRbmIZJeJ3C6QHQpVMuPTkmgNKPs8Q==
   dependencies:
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-enter@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-45.1.0.tgz#9315d897499bedcbc96942ebd4d61e8353c7a8cc"
-  integrity sha512-TWuTFnSwFdnw7FPQBZL8rMEL8YCZ+9FXyNZua2tQ07trMoLHMyP7iiiCNhReDX3DIdnGMAQVMLnTMO3Xs6puhA==
+"@ckeditor/ckeditor5-enter@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-46.0.0-alpha.0.tgz#5e64ae78432169280801a9042d8c9221a4812a9e"
+  integrity sha512-1YWGxjRXcQNEBaVwjfT11O4eNVI9DBgC7/BQQH/lN7mJf05jeXI0gtsbP/Y36Ccea+oNhfbuM4Ik6t4t7VDoLQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-essentials@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-45.1.0.tgz#ef322e006f9dfbc760a2c38bec5342d89ca9b067"
-  integrity sha512-ktQUTvbGHZdTcv/9Pt+LYi1ur6nuypf3WhosGkoqYCh6MOBlLwrtpsEY7hJpPwfZxFl548gCQXSMy4V2ePoVyQ==
+"@ckeditor/ckeditor5-essentials@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-46.0.0-alpha.0.tgz#d6f2765cd337f8a6c50b920fddb34fdf130ab52a"
+  integrity sha512-OxolgF1YqQXQGWZQFNS3rj3kd/dVBoWZKsL0/K8Po6drc+UjbbpT2U9uQU+LCYUTYem/XXTAg85RUBfwZWwYXw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-select-all" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-undo" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-select-all" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-undo" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-export-inline-styles@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-export-inline-styles/-/ckeditor5-export-inline-styles-45.1.0.tgz#4c2ebf70ca7c1120c6878ee8c05ea865cbf7fe8c"
-  integrity sha512-76kLz8h70sAy8bRT2OOFGN19ku1Kys/F16yOb4E7wjXcBE0Q2fAPrgXMcLSHVARGIDTA9uc1gKFKu2NFnYzYAw==
+"@ckeditor/ckeditor5-export-inline-styles@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-export-inline-styles/-/ckeditor5-export-inline-styles-46.0.0-alpha.0.tgz#d5017d98111d13d29d584e2d2d754daff4a59e2d"
+  integrity sha512-XYiTZ8Q7s+XYwHtFCvI9TbKBomVOWolpOXbypdoMuitwzEmEUD17gEH7VYNeeT5W0ziloC52s992ArzcU28rBA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
     specificity "0.4.1"
 
-"@ckeditor/ckeditor5-export-pdf@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-export-pdf/-/ckeditor5-export-pdf-45.1.0.tgz#dd75c7b658c06013486370a74e905a16e539611e"
-  integrity sha512-O9qQY58mEJGbQJ11I1eSSnHrTBwkH/vTUCUvsQhyR+jiSyqR5hhuonkXfSTr3O1utGOb0bFI/fwwXlj3xQL9yw==
+"@ckeditor/ckeditor5-export-pdf@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-export-pdf/-/ckeditor5-export-pdf-46.0.0-alpha.0.tgz#1e2025210263b041dd1a477e5c140d14a13a6f06"
+  integrity sha512-wVILaL9pdR+CT8VmWzRoiuB+YVr0jzeR3MLvChFuajYI6UPju2MQQ+1n9IILaX944IHXc7hn52V9FNRDeaFkAQ==
   dependencies:
-    "@ckeditor/ckeditor5-cloud-services" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-merge-fields" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-cloud-services" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-merge-fields" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-export-word@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-export-word/-/ckeditor5-export-word-45.1.0.tgz#caad38f56b89102cab66efea662c5d684095d31c"
-  integrity sha512-RD1qmB0vbL5rMUjGKKE5dQ+RZeWQt4xm4DLOSp4CUvgTi0kM4CxwRPdIydp1SurfqvFrxaJ0WHQ569gxGKV/3w==
+"@ckeditor/ckeditor5-export-word@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-export-word/-/ckeditor5-export-word-46.0.0-alpha.0.tgz#6ee3b3c75a06d0b111de370b7bd71db093a6683f"
+  integrity sha512-FKMYiuS8l+PyixAWDDAFVNZybAiHt1eEWS2ZnyOog2xHhRb3aVGGJuWsWLs6ZDaM6UI83gNv3pbz/CaIkSLP7A==
   dependencies:
-    "@ckeditor/ckeditor5-cloud-services" "45.1.0"
-    "@ckeditor/ckeditor5-collaboration-core" "45.1.0"
-    "@ckeditor/ckeditor5-comments" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-merge-fields" "45.1.0"
-    "@ckeditor/ckeditor5-track-changes" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-cloud-services" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-collaboration-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-comments" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-merge-fields" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-track-changes" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-find-and-replace@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-45.1.0.tgz#71a199fe2e8e383e9fc3b0f57ca2285326f5df60"
-  integrity sha512-0RwInpUvjFll1Trl0B0KCtoWmWQLrClnTu1Eol1SPnY2C/oYroB8I7UPHChhwvSNaw1l8FYuXx4uyaQoSXSQMQ==
+"@ckeditor/ckeditor5-find-and-replace@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-46.0.0-alpha.0.tgz#aadcf5f4cffff0694dcfa626e0eb262a586dd411"
+  integrity sha512-5nPdBuq91auug3HvXDpkQaTHZPJT/z5xxBZ1tmpkeHP+waXt7Nclr96knlvpHcjOR47pTGsRlwyw8gwPmUxpHQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-font@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-font/-/ckeditor5-font-45.1.0.tgz#a48232b8f232871d65adccafc39abc0573b9f861"
-  integrity sha512-7DqUhpoRYRajDWYFa2hIBypjNJ6Y6XwwiQO1UFZc0TFzbF0pqjRAqrE1Tq8Y5L9IGFUKW/H2pSG/OLcuxdBKoA==
+"@ckeditor/ckeditor5-font@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-font/-/ckeditor5-font-46.0.0-alpha.0.tgz#7dac9b34dcc4f586071e322a182d277877f1f031"
+  integrity sha512-RtAycEYEGS7xG6nMbvweJ4N0gw/YmppnHwHeTLzBkOPDAyEx9W3Up8YAxFKFc/2f1/mvAm8UDjgpKQ849vVJDQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-format-painter@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-format-painter/-/ckeditor5-format-painter-45.1.0.tgz#fb219908852d5ff53fccb4c8c8a96832111c3a89"
-  integrity sha512-6LWcFQ7R6M81fKra4CcReSzSDL1P52Z/mvWgu5/wXGvcjb8MU9svIQyE5Cx54FC9ub1/QOyJl0yUu4kQ7SYNLA==
+"@ckeditor/ckeditor5-format-painter@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-format-painter/-/ckeditor5-format-painter-46.0.0-alpha.0.tgz#b9c881e5c7b1c5354113f67bf14e1bde2f317956"
+  integrity sha512-4bhB9U0rtRAx1izkMXAjzkgYFR3bpZ7kNoS+nhbmkKe78k79wri5zntsm2p41wjV1WDLOnU7v4kNuw9FykBLJg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-fullscreen@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-45.1.0.tgz#792961dfd009364f27c84a76b443766aba35eac0"
-  integrity sha512-K+ON+IHuGU0tHOyevwGu71l094NPcLVqmal7fQ8gzydztyR/7SiaBBgi4tKO3gz7T/PCCwszV6dNS2GLFOSVPg==
+"@ckeditor/ckeditor5-fullscreen@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-46.0.0-alpha.0.tgz#02b01ae94ad87eaf74505a0ac0f65d4a28980046"
+  integrity sha512-e/3ak9xSJ+gcVpWYZ75cKjhOXdjfQ45QtEAxg+mRt24kT4Px0VKWNlTQepq2lTbCUvmMbeVIQzte90qW2j+MsQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-editor-classic" "45.1.0"
-    "@ckeditor/ckeditor5-editor-decoupled" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-classic" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-decoupled" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-heading@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-45.1.0.tgz#6d1e29e5ed376e46ec737f998fda51f72e519e50"
-  integrity sha512-E5VNB4cMGLIVzyPmDEABuJu4jK93qVdTTzM80w68xPYPsLHJs9qcdix1XbZm52Bd7oEXLMFI7XRw8MxNoYNxgw==
+"@ckeditor/ckeditor5-heading@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-46.0.0-alpha.0.tgz#2ee48c4f5ade9e0f6bc99b71720eb1989b8cec31"
+  integrity sha512-hS27i7WoLqI7htkJLiXBOkni8qhpsQjQaOy/mbKGKlR5eEqhPAyfH7SsNGy3ZI2ZKR3tOyGeBUAtpDT700eQBg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-paragraph" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-paragraph" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-highlight@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-45.1.0.tgz#1ba43bc2358bc476dd021abd0d9711b274195331"
-  integrity sha512-zu7SOeKHEiU8XxRvwHC2eliYADERxsLppx7al9MhBUqfBhKGK5clOmvG7gjn88pGazmAs4iAABKy6pV0AJZSpg==
+"@ckeditor/ckeditor5-highlight@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-46.0.0-alpha.0.tgz#1bed32680a09b4852bebecdcc6441ca1f994af4c"
+  integrity sha512-HX4ShiKIqtYKV2H88eAlPmRJPdl08cmelW287mWpBkkiu/5qVIJK5gdIAi/LVmxKEKMphthJfiVVL4aZp15ugA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-horizontal-line@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-45.1.0.tgz#ebee1bd0eaed9563442c473596e62217e6adab23"
-  integrity sha512-R2BUcsm46LzV/UtLoXPKBOKQfEkvrfFSsyNR699yK0XdiRBAd54t/PX62vckZ6irU77hk7NhM7R3qnxd6hqV7Q==
+"@ckeditor/ckeditor5-horizontal-line@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-46.0.0-alpha.0.tgz#625ff73e49a03278dcc9c5586eea4ecb424d7753"
+  integrity sha512-2ZCqFsEufSxTkTRdRNInjximK/mAF+iEULnBa6pvlD10jU7N5gXPTwHf7pu0H9iyjRY/y/wEoMiWrEYnL9ubxQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-html-embed@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-45.1.0.tgz#f4061e2f3ac4f967e68da1b15ecad0f2adffee2a"
-  integrity sha512-LIC7FoQcusjp5tJ4PvYp3XwuPIOoEPevJIzXb8OBC1+8FwE9Iqp4Qg+3JIOS+wpmQymq/IpNAXJ4jzZ1QFUoSQ==
+"@ckeditor/ckeditor5-html-embed@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-46.0.0-alpha.0.tgz#0010c546dbfc045db3866663712a1c11f646811c"
+  integrity sha512-sgx/6/njSP+oZ5uymgp2ax4YpRT5iGjgcQuoN9d74warHirqPy69K/6WpF7UkmBSxLd/P5W8zRPikXa6U3J2ag==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-html-support@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-45.1.0.tgz#20dc10d41ddf9e571537277d5e65a562d68097a2"
-  integrity sha512-U1e9XiHHvcilUJ1bN1Wut/54ZLVxH2+LDhuokeBo7/erY6Q2HEIKSL/92bQykr8mnVSuZoKa7mFXHLMg5tLlQQ==
+"@ckeditor/ckeditor5-html-support@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-46.0.0-alpha.0.tgz#dc96da5e041a099b4385de487e253b148704f0e0"
+  integrity sha512-rutgQapxIZpo7Ous5q6rzntUwXlxAB/MX55Sw+2stWNTOvVHiGYA2VUvqJS7r1sOKZHLilRmguVXWX1aoX4Dtg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-heading" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-list" "45.1.0"
-    "@ckeditor/ckeditor5-table" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-heading" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-remove-format" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-table" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-icons@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-45.1.0.tgz#401c4fa7ae7a3c3779e73eb7e4c855e37dec70c0"
-  integrity sha512-DeRpYnTn+Eng7HBvvn/y46C/du48dVGs7NHfY8kXLOCMY0G30fb1KrdqaYy92Rdsd/vZKCkPcXHw7PchRPbepQ==
+"@ckeditor/ckeditor5-icons@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-46.0.0-alpha.0.tgz#1939bffd882efb88abaa8f0044e442a10a40916f"
+  integrity sha512-9PSUns3wYIMSqdnmuJUN313QH10X1ciDDdSW99V78ttrBh6z5k8b+ZZhvQM5Vd8jz2E0gPMmT2voG5Nw1iKpxA==
 
-"@ckeditor/ckeditor5-image@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-45.1.0.tgz#0cc7d2013f61b07e1fab8171ad95c0800e0eb372"
-  integrity sha512-FOazPw6gCtWIEJQFnkcfuWZk2Z12q49ZSlegEvPsF8uM6ltayb6ywk5B1EGarmMQmuk7fDaCliHJ54P53LklKA==
+"@ckeditor/ckeditor5-image@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-46.0.0-alpha.0.tgz#a10dc944c609c7eaeabeb2827f4dac260ab9a207"
+  integrity sha512-7clC3VTXYRrfjcxOcdYM/1HkdqwJBGdt3UAJnDkCWffuO5tQlI+b254nl2WijstfMoo26s7b/dHPY12qM6nPMw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-undo" "45.1.0"
-    "@ckeditor/ckeditor5-upload" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-undo" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-upload" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-import-word@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-import-word/-/ckeditor5-import-word-45.1.0.tgz#500536c3eb430d93f1a9c204fd2baeae5eb0193a"
-  integrity sha512-zUFDIhhPHjZJrPK0/7l3sGYYk47JJNKc8Y6tm/Iw6P+h12SkH9ZgCilCjzO+9+dKh81ytVRaMuVfi4XPctNOCQ==
+"@ckeditor/ckeditor5-import-word@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-import-word/-/ckeditor5-import-word-46.0.0-alpha.0.tgz#520c5f1f92fd8be706b2348c123d473858f7a5cc"
+  integrity sha512-bN62M210ZlpipLiX4n4oVjT4HauG828wm+EFn9FUpVT7uyWk+aeOlEnBRMwnVEv/dP5h3OMPdptMNu7sgPWN+A==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-cloud-services" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-merge-fields" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-cloud-services" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-merge-fields" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-indent@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-45.1.0.tgz#a153a6dd8fb09344faf1fcb8ae60813c90a03c7b"
-  integrity sha512-Y3nBgYYIuQfcNvAKb9bo1UtEInynp+VG+DriGIvPClU66EcMwJrYg4meA0mzyMFqEARu3G0mn9Ii1KIW1Ix7Cg==
+"@ckeditor/ckeditor5-indent@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-46.0.0-alpha.0.tgz#c1928a81cc249a19cececc0466e38b650f7c07c4"
+  integrity sha512-ikxtyWW0y9e8iARJ1k6lMe/NPI0pOd7aoPC6hcyL0pUo5wMpI7ZKAxLTwXV0rphujHScIPn3tthM/0OkbitFHQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-heading" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-list" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-heading" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
 "@ckeditor/ckeditor5-integrations-common@^2.2.2":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.3.tgz#41c9fdb25f29b2f1c60bd85bd4a9a0b68fd51100"
   integrity sha512-92kQWQj1wiABF7bY1+J79Ze+WHr7pwVBufn1eeJLWcTXbPQq4sAolfKv8Y8Ka9g69mdyE9+GPWmGFYDeQJVPDg==
 
-"@ckeditor/ckeditor5-language@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-language/-/ckeditor5-language-45.1.0.tgz#5b924ba78265e3f25106ddfe3ad2018e1f9d4b2f"
-  integrity sha512-97ghaibmyHr0Lwd4E8lagKngnfdZEpBG0tJ5C5E1OXhu7uhMX201C7/JX4Mw+ZtyZ0fTxdTDiRiypDIoHlbowA==
+"@ckeditor/ckeditor5-language@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-language/-/ckeditor5-language-46.0.0-alpha.0.tgz#fafd1e2553c8b6407327947a2f4693980a3045f6"
+  integrity sha512-sLYxJ937oIUq8pwJXIAR+M2E47vO1BQm6MCPlSqyQKsgEy6rWNHXnW6FANUp6pE+k/xxbTa0mxG+TuZI7aLfmA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-link@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-45.1.0.tgz#2a7576f7cabe056d7e4b13e6ce9a262bbca48968"
-  integrity sha512-/JEHiklcG8mYEveyzhVAKfNSIqk64dqp8v9OkwB6VPFBMN3q7jemRi0gExBc6+HznDjBlM+0nmRB810sQnBuBQ==
+"@ckeditor/ckeditor5-line-height@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-line-height/-/ckeditor5-line-height-46.0.0-alpha.0.tgz#d163dad0be7ef32eee0cd4ca5ca2ee200ad4ece8"
+  integrity sha512-1jn2gX7mWzrdXQh457UtQtQjLqcprMCmZixVnYoylrJGwFM+sWHj/dX1Ja2iiYZsxTJK2aM7sAI+8rvJh6tuIw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-list-multi-level@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list-multi-level/-/ckeditor5-list-multi-level-45.1.0.tgz#4888a2b90f05d65adfd366ff49070efbeaaf5479"
-  integrity sha512-+n0JYBaDLesID/3m7a388KJV7V+FVPhfhkm8q3hrU/9dkiqIqym60p+8XYh1Ud2+w9nDC9QHMr+5He1+q5QxLg==
+"@ckeditor/ckeditor5-link@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-46.0.0-alpha.0.tgz#f21dc255ec2ebef0f16282de05edec9e68fba7e0"
+  integrity sha512-DoFyjoNMC4Dlxe3J5/bdj20VS7dtDh2mg3N9TEsQOQ+A5Kt/NX3IR4XsyUt+BA4wfehRIRTyCwMNX9UOrSF68A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-list" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-list@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-45.1.0.tgz#ce65b6dafe44c2a48fdbe3890ab0c2283d3b5b47"
-  integrity sha512-T4kcaaqAuq0acYnw77G9fFKHDMZSB/X6lqNx0Uh68D/LoXyg44nlP3Bhx2HSeLsBUkrIR1WOTYuya59wF4tkGQ==
+"@ckeditor/ckeditor5-list-multi-level@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list-multi-level/-/ckeditor5-list-multi-level-46.0.0-alpha.0.tgz#019a6e38e6453ddedf92003defc322ae86fa34ba"
+  integrity sha512-2lDGLWU/0A/N0nYXN2F+jx2WHPn70lfrpjOiDKXk1B09yA+uDpAkItW0n0ToztDcXiDTIaThhM1LOtVPK65Tzw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-markdown-gfm@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-45.1.0.tgz#0adf10275accb20e22ea237972ec8311d23c7158"
-  integrity sha512-stJpJC1KYiwYcJwzUmj5eg+g4GPz/rg/guiyN30jXDv0fRoUevsebhjCt+21Iwk9p1fvdcxm4At79k70MSVqtw==
+"@ckeditor/ckeditor5-list@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-46.0.0-alpha.0.tgz#71a754457449458ecf2e60001260f08fe9baa981"
+  integrity sha512-0ldBNCdXSdncpD/hLdd8LOSP4ZHdZu2agXMYPt0jnb0paVc5E05A8ERa6X9qB1Cj7WvzoXPUNhR3NLkWZ6jR6w==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@types/marked" "4.3.2"
-    "@types/turndown" "5.0.5"
-    ckeditor5 "45.1.0"
-    marked "4.0.12"
-    turndown "7.2.0"
-    turndown-plugin-gfm "1.0.2"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-font" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-media-embed@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-45.1.0.tgz#774026135ef0237df1e5078d4db9e7901c91b801"
-  integrity sha512-5mQEVb6P1AOH64CucfyAAE7NRf65VkVQUDfPxfbtXXAnwfVCW5PCoE3ksW3TV7QbZGlL6zlZEfP4wnJjpKN3Zw==
+"@ckeditor/ckeditor5-markdown-gfm@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-46.0.0-alpha.0.tgz#049d4b86c1321e55ea1505154fbdbaf32dda8cfb"
+  integrity sha512-F7gazUKNIZ2AL3ym9/yOHOE2NVUywbK1Y0F/sJNv6OIPATa0YqlIugvewwHId9AMK5CHxjco3hcB4l5JaQI/jA==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-undo" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@types/hast" "3.0.4"
+    ckeditor5 "46.0.0-alpha.0"
+    hast-util-from-dom "5.0.1"
+    hast-util-to-html "9.0.5"
+    hast-util-to-mdast "10.1.2"
+    hastscript "9.0.1"
+    rehype-dom-parse "5.0.2"
+    rehype-dom-stringify "4.0.2"
+    rehype-remark "10.0.1"
+    remark-breaks "4.0.0"
+    remark-gfm "4.0.1"
+    remark-parse "11.0.0"
+    remark-rehype "11.1.2"
+    remark-stringify "11.0.0"
+    unified "11.0.5"
+    unist-util-visit "5.0.0"
 
-"@ckeditor/ckeditor5-mention@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-45.1.0.tgz#d1b9f2d6f933075dd0056f5f8873d6ccdfef77a7"
-  integrity sha512-gbcuEqeI+AwQJ4TdCFKPQNWgWdr21Ht/b5KE0n/AvQHHW+KHzTTRQl+gKrt6CGCkC3MpllEokG7xhL7hHyyrpw==
+"@ckeditor/ckeditor5-media-embed@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-46.0.0-alpha.0.tgz#1cae844503a0c98b7b6a272dce92052bc3906bca"
+  integrity sha512-nKUd6C6UQnf12YLAFyNa+wOxJeReliGUmySuTQPCTlCrrVl/2hXkP/f9ZUiP1DnfBvLY8pU1Y7OGQxpYa1o8xw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-undo" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-merge-fields@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-merge-fields/-/ckeditor5-merge-fields-45.1.0.tgz#2175d101c3395fe602d0adfaa92c8bc282ec205b"
-  integrity sha512-YCJC9oPHKBTjLmNRP37wbwpbvIt3FvN3gtEb7niZXy0T3YW5BigCFKWaHqH3YuqWn0ErnuZqlo7rKIkpMtBTjQ==
+"@ckeditor/ckeditor5-mention@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-46.0.0-alpha.0.tgz#7b86db76d46b4a5687f974107ff7dba013dea1ad"
+  integrity sha512-s1PMqzjzwVd3UF6VUgFJT3b9ObS/4fg8/nIg4GW2adVj7RuSNLMPGsFuNa4NEnBVFI4vbBDBzKeCJ1H82vUjJg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-mention" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-minimap@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-45.1.0.tgz#2912889db4b9f347ab6bf31526240ee21673b7a8"
-  integrity sha512-mBkfs65+3tJUsJQjduW2zPuIsg4Q72Y2JSPr0Gw1+XYaEekZfCbhj1x6LvWQFy1waZQk7TvlBxGNTCQjo4DFBg==
+"@ckeditor/ckeditor5-merge-fields@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-merge-fields/-/ckeditor5-merge-fields-46.0.0-alpha.0.tgz#a10a6135b59ea6bc5c7ece8d3fc6b4ac7d03e5e8"
+  integrity sha512-taAjGA9DBomXb4wGZEh4jAIuUXUb2gbsOPW0ohHL0tbfScSZYMGKJghMEM30/bYCVD279e9yMYIX24qVvCqc2A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-mention" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-operations-compressor@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-operations-compressor/-/ckeditor5-operations-compressor-45.1.0.tgz#ad201b84aedd76a48cc56b53c456d33524ec0481"
-  integrity sha512-uC8db39kQhX75tKigqj6e5wck8qoTXwFcrEd9eGMW9rGETRO79stEj+MqV6g3Ur5EQ4PKZEo4qv1B4Q9DfZGEg==
+"@ckeditor/ckeditor5-minimap@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-46.0.0-alpha.0.tgz#7b6ca0847580ae3bc28744a384f7ce3b1edb9aff"
+  integrity sha512-tlJdoSlcreem3N3bYep/3+vXkD2kFA4UlRqZfaoOQV4n26FTJyx5RP3AVpEXwGkmLYtQ2svffCkAT7Aa66RS5g==
   dependencies:
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+
+"@ckeditor/ckeditor5-operations-compressor@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-operations-compressor/-/ckeditor5-operations-compressor-46.0.0-alpha.0.tgz#e23924b32e5129009048cac62ef08d7e833cd831"
+  integrity sha512-UGqYYb3fLzi+VTd/Exu6L4/kUFus1gT8+Oxwvfb2zxuHQEpaOFKvAswsgOFp07uDQTmJMRMXXCAeATGy1Mz3XQ==
+  dependencies:
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
     protobufjs "7.5.0"
 
-"@ckeditor/ckeditor5-page-break@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-45.1.0.tgz#f8ae7aec2a680247a533b538a69854bf87d5a353"
-  integrity sha512-O2hNGkvz88Kpy9vlhByd/7p81N5w1htuLTqS+fojpoFV13rwbwyX0g3EOVJwk7uSEk0L1iomNo1zDu87sNkKIw==
+"@ckeditor/ckeditor5-page-break@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-46.0.0-alpha.0.tgz#976985be9573dfffff534106baef1a673b105aad"
+  integrity sha512-z3DhepMObcf+AiKWN4kbu86thTFFUGFhJIVJMqfRP+QuD8AI47DLKjU5n9qk/Xe+oc9bo7tap5EZoHxbirPh6g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-pagination@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-pagination/-/ckeditor5-pagination-45.1.0.tgz#2e990edf1a983c8cf0db95c3f5639cfd0b292d9a"
-  integrity sha512-mQNFgUJbeXR/rB+GRBWNT4mWm2dqWIxYiaHFupnLy84hvzPvB3725d/3MKhb+68LAvmV1BKhRyD+oaqPKmf5pg==
+"@ckeditor/ckeditor5-pagination@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-pagination/-/ckeditor5-pagination-46.0.0-alpha.0.tgz#5772d8a07e339741f1c7398ff420133c694dd85f"
+  integrity sha512-E5rkNIVaenqnIhGG4d926acSOf7pNCfz/QyKj0ImY8xIpPuszEKAVaODwTjdGgZgTeuP3HWX8LAqGm3Hp6xB+A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-paragraph@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-45.1.0.tgz#5cd1352a60b2f01f442380a928f24e7a4e0eb734"
-  integrity sha512-FST+msgRQ8M9pEiv9Whhn2v0H1hhwlfccf3BKxZ6BI7o2V1HyOZ5l9NxCKhD4ujN5mw9whAY5TrTApwyXEZqXg==
+"@ckeditor/ckeditor5-paragraph@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-46.0.0-alpha.0.tgz#b8c9f493ca03125ed857a93abac8ea5e45ea318e"
+  integrity sha512-zCOjSU2rAwjHrvpIK50ovlII1E9puqDv28MnbekMrBC2SjN2Yy21wJEOF8NuzofoNj/gJUFCgfvbMeAiVBQWIA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-paste-from-office-enhanced@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office-enhanced/-/ckeditor5-paste-from-office-enhanced-45.1.0.tgz#8c5c77a0d0bd2708ca222aa525358012e07d1bb2"
-  integrity sha512-pTXElxG/CRDFKZdyWnGfBW5ptwAXhX/nYzo1B1HFZlrAW1j+JEhC1JnQ/s3HyWEyfp0hZbBjMUkA+jKYhWPBzg==
+"@ckeditor/ckeditor5-paste-from-office-enhanced@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office-enhanced/-/ckeditor5-paste-from-office-enhanced-46.0.0-alpha.0.tgz#969a36fc0cc8b99f00446557d68897ab5cfebf96"
+  integrity sha512-EFcvJP11oYHVMwgRD1OBg323whdKlODZLEtzt1Bl8xzLmcosNmwlrgFN3H6HE0JOpaFPzXAYWDUsgZGTOs4+1w==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-paste-from-office" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-paste-from-office" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-paste-from-office@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-45.1.0.tgz#ee90833137c05024febe2aad508cd41c67490748"
-  integrity sha512-AkvINYiuEF+D0DuJT7+tMwYCUmWWys8hwksvotihi6rU574UKf4pBrwYip+1BQuQ9FSb142/LUfixRRU39cKZw==
+"@ckeditor/ckeditor5-paste-from-office@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-46.0.0-alpha.0.tgz#db3b21ad71eea02c82e8f4eb748e63616141856c"
+  integrity sha512-OmfBJSh/+2N/Bz5BSu8nt82CziTtOdOb2GV51i/trGMEfjr0o3NkYlnSBr24TRkbSlcga1KSnzY/ynXfLQOnYw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-real-time-collaboration@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-real-time-collaboration/-/ckeditor5-real-time-collaboration-45.1.0.tgz#8e1b016fad86de14168724f087d8036c2f999f3b"
-  integrity sha512-4WDHcETrw8fh5UKaARuPcTXqDwBSF5PqqkGRP/XhDyOsQJE/e9y8KVejRKp6w+fZ5FMkDwYEQyoU+HyvXOWNhA==
+"@ckeditor/ckeditor5-real-time-collaboration@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-real-time-collaboration/-/ckeditor5-real-time-collaboration-46.0.0-alpha.0.tgz#f1d9071ac601a4e9f70bb1053f78b06097b6ed48"
+  integrity sha512-VK00RH5p/NoTS8dEBNtRSwGpHbcrNILU+/T+hnqNjlxklOtyhTTr3jsrBnuZvIuyMmUYmxQdwZwDs+ZCxc2h3w==
   dependencies:
     "@ckeditor/ckeditor-cloud-services-collaboration" "53.0.0"
-    "@ckeditor/ckeditor5-cloud-services" "45.1.0"
-    "@ckeditor/ckeditor5-comments" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-editor-multi-root" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-operations-compressor" "45.1.0"
-    "@ckeditor/ckeditor5-revision-history" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-track-changes" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    ckeditor5-collaboration "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-cloud-services" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-comments" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-operations-compressor" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-revision-history" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-track-changes" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    ckeditor5-collaboration "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-remove-format@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-45.1.0.tgz#db993ff74ee712593fdafb701d77554960891815"
-  integrity sha512-+6ml8//kp34HthxS5DA9XGJyJ9dw0Yxay6aqpbDYGIyClJTdwlUPjVuOAnRZfKhY/BW5ZZJrQleNww97YnUlfQ==
+"@ckeditor/ckeditor5-remove-format@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-46.0.0-alpha.0.tgz#eb9dd9e0a8d108ac3ddf2f87f7f2eab12c46c3d9"
+  integrity sha512-5wM4FID+SPv8jQPe79ydNHCcPAV+0e6muwOIKFira125wb1SYAvrAfpw4uBD9cUTU+MPFpvL8I1WX1ZpN46PZw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-restricted-editing@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-45.1.0.tgz#fbe8ed2f63215feb2993675fa7115618188997c3"
-  integrity sha512-qsYa9PpFnRXsBp6LbcsHbADGaVLQP91qGwFLiXNeaR2I0eYbJywRf+wbfgILGvhsQgZNLKld0AIM6h/yBqOTRA==
+"@ckeditor/ckeditor5-restricted-editing@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-46.0.0-alpha.0.tgz#4f47e17b1d672b0a466c9093af0b7fe7c12aae0b"
+  integrity sha512-BuwJWmqcMYdE8zwQ+Vql06P++fK7/QQmPohdQFaKq4dfSO3O2iheNL55EG8NAJeP5k/4o0ovblxEfxzW2zfREw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-revision-history@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-revision-history/-/ckeditor5-revision-history-45.1.0.tgz#33b5b334eb49f434c957fcb5ce82bcb55e8c70f5"
-  integrity sha512-hylGZgTd/JTTmzDoZ6iTGt4egKgCxvUKKSjEDCyTcAnivqFW1Wxtznwp2KtYHzOxcB/Szpd3ZdyUDdOTusv80g==
+"@ckeditor/ckeditor5-revision-history@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-revision-history/-/ckeditor5-revision-history-46.0.0-alpha.0.tgz#805b68d27623b06e617c9f41384ed608fee4d601"
+  integrity sha512-Jm2UNhGFnk9+c867VPLD9BF1H3oUg6i+cEdApd01z0z9wmmooG9pL9HnGwGnz5KYJtN5IKproxTFgsPkZiLUuQ==
   dependencies:
-    "@ckeditor/ckeditor5-autosave" "45.1.0"
-    "@ckeditor/ckeditor5-comments" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-editor-classic" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@types/luxon" "3.4.2"
-    ckeditor5 "45.1.0"
-    ckeditor5-collaboration "45.1.0"
-    es-toolkit "1.32.0"
-    luxon "3.5.0"
+    "@ckeditor/ckeditor5-autosave" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-comments" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-classic" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@types/luxon" "3.6.2"
+    ckeditor5 "46.0.0-alpha.0"
+    ckeditor5-collaboration "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
+    luxon "3.6.1"
 
-"@ckeditor/ckeditor5-select-all@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-45.1.0.tgz#138475b7be2691c894b05f41d3ba58127d1d5117"
-  integrity sha512-Z/DSArfy7MUfHVaYMp4lJZos6XTiTWuyOzQEwp9BzcpiYyXHSRs+cH+JZYd7x5/JuddF9OsEZIqnS+xiw+PqfQ==
+"@ckeditor/ckeditor5-select-all@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-46.0.0-alpha.0.tgz#ec07b25477d62bda52b25e96eae193a45e53995a"
+  integrity sha512-RaZwgGm+GdnW+aKx0BgSCeLyLAvzhFcgCMgfRRl9a1Bj4PCLrKd8hyk2M8EPObrhod2FTSFdYf9+rycHsSCnjA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-show-blocks@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-45.1.0.tgz#0cdc97d0f8fb0c066c3d338ecd2841b8c69ae489"
-  integrity sha512-61pmHQ82g3qS2ucmxJihFMwKashfJI6xcIHjqu09ctJlwHazq95T76uWH3s0fd5sBBx6cFZ5Dr4Y9Uz+hUc1pQ==
+"@ckeditor/ckeditor5-show-blocks@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-46.0.0-alpha.0.tgz#39d06824673b542c8bad1a4bc675c45b3367c627"
+  integrity sha512-FkK+HYqTqzK3zakt3iC7YJFXYQ5Z40RQAa7Ef66DtksXyCMrQ27rDOKXnrODyfnbXM/S0i7WP6Iv6NnSCmedjA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-slash-command@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-slash-command/-/ckeditor5-slash-command-45.1.0.tgz#e2d3d4a3f0e7234348c7b0f4aff3863dffd639e7"
-  integrity sha512-Kz8dcS/LzZDzIMAfSW5uNN9fWMqL2ppuH7KPV2EzJ85aLICfCZNJH0wSvsZ9a1iKV7w697R0E0BBch6gZWBWTg==
+"@ckeditor/ckeditor5-slash-command@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-slash-command/-/ckeditor5-slash-command-46.0.0-alpha.0.tgz#416c917043537c7831f04ef6e100e9c280d73a1a"
+  integrity sha512-jLbPMS+0ReLmmWEQ9Do9HqnmHQQOmK0hhFZiXV6DhgmiGsssfxWmZHaCq28kx+vkrLFvg2rGCCwf4rT86JAfRQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-heading" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-mention" "45.1.0"
-    "@ckeditor/ckeditor5-style" "45.1.0"
-    "@ckeditor/ckeditor5-template" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-heading" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-mention" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-style" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-template" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-source-editing-enhanced@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing-enhanced/-/ckeditor5-source-editing-enhanced-45.1.0.tgz#aafaac5f17582188303e389d55d08d7f46816e02"
-  integrity sha512-vSBXxVKnX8coMCkAYmAm7OxVrlSZfTbOs6h/LEtWW9Qn6EBXtQiMQQMrHEiTT5KNXEsMJcO5LiWwZlazG94+tA==
+"@ckeditor/ckeditor5-source-editing-enhanced@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing-enhanced/-/ckeditor5-source-editing-enhanced-46.0.0-alpha.0.tgz#de306d6499e87c8ff0b32cb2a8613dcb9b822da5"
+  integrity sha512-/zmg0zGdECYO+tXbNrbyfbFJfMGxJoaFa42I4JzXxFccd+tqRaoONeEhFa5rwtWd+5+pL6nxMrcEHkLWcXQkHQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
     "@codemirror/autocomplete" "^6.7.1"
-    "@codemirror/commands" "6.8.0"
+    "@codemirror/commands" "6.8.1"
     "@codemirror/lang-html" "^6.0.0"
     "@codemirror/lang-markdown" "6.3.2"
     "@codemirror/language" "^6.6.0"
     "@codemirror/state" "^6.5.0"
     "@codemirror/theme-one-dark" "^6.1.2"
     "@codemirror/view" "^6.35.0"
-    ckeditor5 "45.1.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-source-editing@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-45.1.0.tgz#0459fba118827c2867149b1c7dcabafb878c0786"
-  integrity sha512-CDZbYt7903FjHOv0EnKVjmIw6g/Lu6gRMBv6HyDKzG+m3r+1blsCPOWlas7CPPeGsifxGE2+fS67DBuHlUelsg==
+"@ckeditor/ckeditor5-source-editing@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-46.0.0-alpha.0.tgz#7b754a7480f9e45d3f95946f1f5f42fa49cf2376"
+  integrity sha512-52QoydeuNKL2BRuEtnqfoWCNeJJbf9jg7+J7VVitSsn2oR4a/hNSyHXPQu/UNWaYzwN1CyFmvBQ8qlv16JOJ8g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-special-characters@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-45.1.0.tgz#6636dff867f3fd19c52b37f27e50f026d1f7a75a"
-  integrity sha512-mf0crAk0x28c39rY/CatI7UMKv8HLFH4CTc/YvjtTBINqHvUoLuOYvJ9WnJh2SVxFS2YkYnxpfyppHaRp2/z0w==
+"@ckeditor/ckeditor5-special-characters@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-46.0.0-alpha.0.tgz#852f932ef1335ddb5c55b5756a2c523c5e383fd5"
+  integrity sha512-9aLn+qAR5mbYKavmUqXTxYOmGjKvkEDBxEnf9znP79FODmgHBG8QmvYxyvpNEzPDI2QyI8C5YXDIKQk3Fi+SfA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-style@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-style/-/ckeditor5-style-45.1.0.tgz#e45f4c78982397d31f33f47df5bc0122f74af0d2"
-  integrity sha512-MtBgioOzgQJWWoA952o8Y/51LwDaH8KkjYz78qck8fHTCR+aPnUJLs1z53aXq6AKFUFHMpu1QoR+66MIOXpmrg==
+"@ckeditor/ckeditor5-style@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-style/-/ckeditor5-style-46.0.0-alpha.0.tgz#5d222026b727e1819860cb9508bb95d657235ee1"
+  integrity sha512-BdYdwkR3Wa8g/BcALQJ4G5Q0t52i+QC3qTmRm1h/8wulSJxf8Npr9oi9+R6Q7+mF0q7iOYyXYIH9Y+oNOU8REg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-html-support" "45.1.0"
-    "@ckeditor/ckeditor5-list" "45.1.0"
-    "@ckeditor/ckeditor5-table" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-html-support" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-table" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-table@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-45.1.0.tgz#3cf07a5ce9aebd59cf10bbaae40f1455dfe97752"
-  integrity sha512-M3FVHFKSBDhW4NVHRTZkbF8LCBIGX2nnX2B13dpLJArNvVcNfHsPsjM+y6O+lKX/bKgJw7bUTbxSvasoPbyvFQ==
+"@ckeditor/ckeditor5-table@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-46.0.0-alpha.0.tgz#8149f55194098d22f4e72e35ae71f99985410436"
+  integrity sha512-63VfAjeik/fYNAL2/EWCE1wf/LbN6HAq8Met1fIi7G7RikFPTjHDb9y8q88zaIKyUR4taMqL28lBC271d4eoAA==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-template@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-template/-/ckeditor5-template-45.1.0.tgz#39fd701f7de4facde0582d7eb2574248938ece8c"
-  integrity sha512-DgUNVKZfuaYBIMfVxn/KAt2AExRujSN4d5h4l+3P8g+HCYkxNPKg0BhqA6oF3bHnO8AusGinsK8AREVZfo52dw==
+"@ckeditor/ckeditor5-template@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-template/-/ckeditor5-template-46.0.0-alpha.0.tgz#c6f75ac4c558e126fdf8f6a665372c97800d374f"
+  integrity sha512-UE5n9Vmh2IbR1T9zSoFn+itdNyBrUPOomR1p8mX/zK5K9Z8tNJSeDbzPBMv7MAR/BCVy8+zbOOPDzRsA6V6p5Q==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-theme-lark@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-45.1.0.tgz#43718ea58ba6c4f7f77f0943246ab9c3625a804b"
-  integrity sha512-QaoVJ75yfi36uCju+rtUcxzkf0UwqHkZutswhiQ5U0CAp+uC5kKjPUSREFmH7yHY560uTR9Qx40//MB9+URbwQ==
+"@ckeditor/ckeditor5-theme-lark@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-46.0.0-alpha.0.tgz#c672b9da5e062a43feace65e1a6c4430fd8360b2"
+  integrity sha512-ZeOsRx09rocZY4XLeZHioPkYGqL+QTuRJeuwt9oMG61g5hpsSBDu7Fx2on38PnCDJ922oiKCfVABUgF3UpsDpQ==
   dependencies:
-    "@ckeditor/ckeditor5-ui" "45.1.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-track-changes@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-track-changes/-/ckeditor5-track-changes-45.1.0.tgz#8733e341c97c96c4cc5a6ffdac487974d5ed55a4"
-  integrity sha512-1QH/0VzzYABCgICWR3Zt8IedCoiS+bVxqpKMsOLeKSlrLC112yiLRouNYsfCADo6CA2bsDigPnlWepXyQXeNKg==
+"@ckeditor/ckeditor5-track-changes@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-track-changes/-/ckeditor5-track-changes-46.0.0-alpha.0.tgz#24c7701b1a7661f7fd0537d82c8d3174186938e5"
+  integrity sha512-nJvgDKQ5CqssmudMykmDf8ppRT6+RdwCHQp9ghh6BGC18J3NFlXem5s2FfVGgq79nzlT8Cn5vFmk0pnt6PuGLA==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-code-block" "45.1.0"
-    "@ckeditor/ckeditor5-comments" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-editor-multi-root" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-find-and-replace" "45.1.0"
-    "@ckeditor/ckeditor5-font" "45.1.0"
-    "@ckeditor/ckeditor5-heading" "45.1.0"
-    "@ckeditor/ckeditor5-highlight" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-link" "45.1.0"
-    "@ckeditor/ckeditor5-list" "45.1.0"
-    "@ckeditor/ckeditor5-media-embed" "45.1.0"
-    "@ckeditor/ckeditor5-merge-fields" "45.1.0"
-    "@ckeditor/ckeditor5-restricted-editing" "45.1.0"
-    "@ckeditor/ckeditor5-style" "45.1.0"
-    "@ckeditor/ckeditor5-table" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    ckeditor5 "45.1.0"
-    ckeditor5-collaboration "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-code-block" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-comments" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-find-and-replace" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-font" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-heading" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-highlight" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-link" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-media-embed" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-merge-fields" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-restricted-editing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-style" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-table" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    ckeditor5-collaboration "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-typing@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-45.1.0.tgz#cbc68ec77c42edf1259deb1c6cd8244cb8bafbc0"
-  integrity sha512-lItJnsr0cnuM8aFTHHPbiNqh17Z0HDtdiIk9zpv0+t6xIP2kx92vk+ymkhNe44rM2atla6ExqTDkfvm5XOL54g==
+"@ckeditor/ckeditor5-typing@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.0-alpha.0.tgz#b3559d28faf7b30b9964e50b89f0be4332e777e8"
+  integrity sha512-HDc1OeEQhALUlAKCih77QJwg3twcO2kogXT2I1cD8d0FqODxpCvI3tBSkdZ3x6XbhC/away0cPeo8krNPT4GEQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-ui@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-45.1.0.tgz#ee057cd0e3030793e289b2dce03a2a5296799504"
-  integrity sha512-4GynwAhsBxy/dTmVFG3gD4V25qI5rtN7gPF4UjABKIrMPTfF/1+lWXiS/KLUwQ1ftihR6TrwEOQ/AAQk/qEpRQ==
+"@ckeditor/ckeditor5-ui@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.0-alpha.0.tgz#132baa41297a63eac1a0618bdde85fcf059e3cd6"
+  integrity sha512-vVEpObeidthTNgkt7V97E7aiuxIl3hAlszjThTYmvMvjJDAwWbT+0YlvTov/iPP7OIVBe5v9hKXHwxpqYXBbrA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-editor-multi-root" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
     "@types/color-convert" "2.0.4"
-    color-convert "2.0.1"
-    color-parse "1.4.2"
-    es-toolkit "1.32.0"
+    color-convert "3.1.0"
+    color-parse "2.0.2"
+    es-toolkit "1.39.5"
     vanilla-colorful "0.7.2"
 
-"@ckeditor/ckeditor5-undo@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-45.1.0.tgz#4213e3816317adbd68deb4db0be4b2b492a9fef0"
-  integrity sha512-hahSIH+CWqetZaI1cUssvlDuwuSzXprBSNOPlULoyaBHej7otHzsdqWIyJoip+kOOb2gfPUioriIpKVaVd7itg==
+"@ckeditor/ckeditor5-undo@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-46.0.0-alpha.0.tgz#d21819d1806bbccaa4fa7513a873a3d416d26d60"
+  integrity sha512-mQZ3Ss+clEtJUEPgAkSdqsj6k5oDBuekW11QNQrm0OifynpiL9NaAdqwHuhUtOHM9I89Nuwc960U/9D3JCPHIQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-upload@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-45.1.0.tgz#ef4567f108203b9160ee970ee9b473ff98228b5e"
-  integrity sha512-D/A4U4/MTi5N3XAol00OTDzYc6hVjU25ShajvMkh2EVWhS6tdA+himQy2J2JI6KzORU3oCA1eMvuJ83gFFq3xg==
+"@ckeditor/ckeditor5-upload@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-46.0.0-alpha.0.tgz#6934477d538f4cca29f583193dbb47e7785b0d82"
+  integrity sha512-QVnHd1pX8WvwKCR55p6Zsb7Fwsrwxlbw1GRlcQLDaT0z9Lbj+9NzsluaBd1zQAk4q/x0MtIoRI7bnn2UJOW+Jg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-uploadcare@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-uploadcare/-/ckeditor5-uploadcare-45.1.0.tgz#c02fa80da76bd26e84bf03eebcb63317b3dbc5c5"
-  integrity sha512-mCRm/3rlf56+g0NUMU3TIozMcPdo4WQThbcRDTrq6KL55HPE0/PrNVhhg3ly+hINFA+oMxMmsMjAYpS1t8CmTg==
+"@ckeditor/ckeditor5-uploadcare@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-uploadcare/-/ckeditor5-uploadcare-46.0.0-alpha.0.tgz#7304f7e55c809097bf55a498e6414228ac54cd79"
+  integrity sha512-/rt2SbYy/6UdcDjMBFpqgdpUQa5UaxqAzBeF3V0TsERZ9hMGsxcFk5C6rSmkyO4nHJZ4fxvjUXCtHPBGO364Yw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-upload" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@uploadcare/file-uploader" "1.12.0"
-    "@uploadcare/upload-client" "6.14.1"
-    ckeditor5 "45.1.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-upload" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@uploadcare/file-uploader" "1.16.3-alpha.0"
+    "@uploadcare/upload-client" "6.14.3"
+    ckeditor5 "46.0.0-alpha.0"
 
-"@ckeditor/ckeditor5-utils@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-45.1.0.tgz#81dc6809d6161ef9cba4ac17ccd5b2435ce435d8"
-  integrity sha512-YxGWzvlT0Is6L34Ejyl/TLASS9CCM8jDZjkqT2k4Zu9+xmkOsrPGKbL1az60NVD7rSGdY/DBDagxQNLzxMjUiw==
+"@ckeditor/ckeditor5-utils@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.0-alpha.0.tgz#b5b6e1b3fbb792917a27bb2ae5ae473ad25f214a"
+  integrity sha512-cQeCGU79bsAN650RoKuUzZYbwBiNg6kvXkigFt1DqW5KdAokG6r+N5TZspkGU1LYeWVuRbVgK05Q/2DIGCI7pw==
   dependencies:
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-watchdog@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-45.1.0.tgz#913218c27e6ea7581e0b1c4571b6a7aa9f95b5c3"
-  integrity sha512-+qnHn30D9QDbtp1VdzO3gpnUBQKLxQqTS+2O5k9DxwLHErDcQGTudIpwZhdwESzjBjzB8De1lS1Ftzvn7Q+nyQ==
+"@ckeditor/ckeditor5-watchdog@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-46.0.0-alpha.0.tgz#3b860312aa294c606a047c6aae70a25ba2fd3bcf"
+  integrity sha512-eq5/ROE4AMuGQKCErMnI6wp3g62iTLzKfg/SDOaRE4cjvkHb8HOiHXSI02L1IYkpryGS1eR1+kmjLmNp1Id56A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-editor-multi-root" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-widget@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-45.1.0.tgz#f2eb9d8149d7c4e6411c779e619c040d0f589223"
-  integrity sha512-MzAw89pG29QOTBJchtqqr327RdNK28R4b+eBMB2LwAGz9c6wVZjyepn8ZqiKtACvNZ2aC2xgdJOGvpZ4VJiqTA==
+"@ckeditor/ckeditor5-widget@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-46.0.0-alpha.0.tgz#d0415e67e24ff729e22b7f1553309792301770c0"
+  integrity sha512-5Y7UeMjwqb3iuckRhAWPRAW7Mfl+v/+Ro1f7YVaG6OhM/VhV4Xf9vdoPWE69Eb/FItrNdLGbjimrL/A+fr/H9w==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-word-count@45.1.0":
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-45.1.0.tgz#9743f87af91a806f0e39f16c5c68f09429fcf26b"
-  integrity sha512-CW7yktPoxakqOAniY+xDY5MAvdpIMvULj6XGWHskgB8VdumcaWF74Nam/mE5Hs2WuKMNBgTnFnsdGoRSGlpJzg==
+"@ckeditor/ckeditor5-word-count@46.0.0-alpha.0":
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-46.0.0-alpha.0.tgz#afbb4542db6999a862f947727463cedebba6107c"
+  integrity sha512-H5KDSRtZy3YwEsC2UVl16S6Yb9OuwkRHceLVIuwyeHIpPk6sxHqhy7zE1o2de04Io5/zPs8bLctag8sVdiYSiA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    ckeditor5 "45.1.0"
-    es-toolkit "1.32.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    ckeditor5 "46.0.0-alpha.0"
+    es-toolkit "1.39.5"
 
 "@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.7.1":
   version "6.18.6"
@@ -1862,10 +1888,10 @@
     "@codemirror/view" "^6.17.0"
     "@lezer/common" "^1.0.0"
 
-"@codemirror/commands@6.8.0":
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.8.0.tgz#92f200b66f852939bd6ebb90d48c2d9e9c813d64"
-  integrity sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==
+"@codemirror/commands@6.8.1":
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.8.1.tgz#639f5559d2f33f2582a2429c58cb0c1b925c7a30"
+  integrity sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==
   dependencies:
     "@codemirror/language" "^6.0.0"
     "@codemirror/state" "^6.4.0"
@@ -2631,11 +2657,6 @@
   resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
   integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
 
-"@mixmark-io/domino@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
-  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
-
 "@mswjs/interceptors@^0.37.0":
   version "0.37.6"
   resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.37.6.tgz#2635319b7a81934e1ef1b5593ef7910347e2b761"
@@ -3104,133 +3125,123 @@
     "@sigstore/core" "^2.0.0"
     "@sigstore/protobuf-specs" "^0.4.1"
 
-"@smithy/abort-controller@^3.1.9":
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-3.1.9.tgz#47d323f754136a489e972d7fd465d534d72fcbff"
-  integrity sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==
+"@smithy/abort-controller@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-4.0.4.tgz#ab991d521fc78b5c7f24907fcd6803c0f2da51d9"
+  integrity sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/config-resolver@^3.0.13", "@smithy/config-resolver@^3.0.5":
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-3.0.13.tgz#653643a77a33d0f5907a5e7582353886b07ba752"
-  integrity sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==
+"@smithy/config-resolver@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.1.4.tgz#05d8eab8bb8eb73bec90c222fc19ac5608b1384e"
+  integrity sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==
   dependencies:
-    "@smithy/node-config-provider" "^3.1.12"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-config-provider" "^3.0.0"
-    "@smithy/util-middleware" "^3.0.11"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
     tslib "^2.6.2"
 
-"@smithy/core@^2.3.1", "@smithy/core@^2.5.7":
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-2.5.7.tgz#b545649071905f064cb0407102f3b9159246f8d9"
-  integrity sha512-8olpW6mKCa0v+ibCjoCzgZHQx1SQmZuW/WkrdZo73wiTprTH6qhmskT60QLFdT9DRa5mXxjz89kQPZ7ZSsoqqg==
+"@smithy/core@^3.5.1", "@smithy/core@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.6.0.tgz#be02f2a4a56ba83d37298454a0bddc89cbad510b"
+  integrity sha512-Pgvfb+TQ4wUNLyHzvgCP4aYZMh16y7GcfF59oirRHcgGgkH1e/s9C0nv/v3WP+Quymyr5je71HeFQCwh+44XLg==
   dependencies:
-    "@smithy/middleware-serde" "^3.0.11"
-    "@smithy/protocol-http" "^4.1.8"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-body-length-browser" "^3.0.0"
-    "@smithy/util-middleware" "^3.0.11"
-    "@smithy/util-stream" "^3.3.4"
-    "@smithy/util-utf8" "^3.0.0"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-stream" "^4.2.2"
+    "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/credential-provider-imds@^3.2.0", "@smithy/credential-provider-imds@^3.2.8":
-  version "3.2.8"
-  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz#27ed2747074c86a7d627a98e56f324a65cba88de"
-  integrity sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==
+"@smithy/credential-provider-imds@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz#4cfd79a619cdbc9a75fcdc51a1193685f6a8944e"
+  integrity sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==
   dependencies:
-    "@smithy/node-config-provider" "^3.1.12"
-    "@smithy/property-provider" "^3.1.11"
-    "@smithy/types" "^3.7.2"
-    "@smithy/url-parser" "^3.0.11"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
     tslib "^2.6.2"
 
-"@smithy/eventstream-codec@^3.1.10":
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-3.1.10.tgz#0c1a3457e7a23b71cd71525ceb668f8569a84dad"
-  integrity sha512-323B8YckSbUH0nMIpXn7HZsAVKHYHFUODa8gG9cHo0ySvA1fr5iWaNT+iIL0UCqUzG6QPHA3BSsBtRQou4mMqQ==
+"@smithy/eventstream-codec@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-4.0.4.tgz#35abc26d6829cc61a0d14950857ccc5320bf92d2"
+  integrity sha512-7XoWfZqWb/QoR/rAU4VSi0mWnO2vu9/ltS6JZ5ZSZv0eovLVfDfu0/AX4ub33RsJTOth3TiFWSHS5YdztvFnig==
   dependencies:
     "@aws-crypto/crc32" "5.2.0"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-hex-encoding" "^3.0.0"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-hex-encoding" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/eventstream-serde-browser@^3.0.5":
-  version "3.0.14"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.14.tgz#0c3584c7cde2e210aacdfbbd2b57c1d7e2ca3b95"
-  integrity sha512-kbrt0vjOIihW3V7Cqj1SXQvAI5BR8SnyQYsandva0AOR307cXAc+IhPngxIPslxTLfxwDpNu0HzCAq6g42kCPg==
+"@smithy/eventstream-serde-browser@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.4.tgz#0c57cf0b66862106100a796751003733ce3f5273"
+  integrity sha512-3fb/9SYaYqbpy/z/H3yIi0bYKyAa89y6xPmIqwr2vQiUT2St+avRt8UKwsWt9fEdEasc5d/V+QjrviRaX1JRFA==
   dependencies:
-    "@smithy/eventstream-serde-universal" "^3.0.13"
-    "@smithy/types" "^3.7.2"
+    "@smithy/eventstream-serde-universal" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/eventstream-serde-config-resolver@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.11.tgz#5edceba836debea165ea93145231036f6286d67c"
-  integrity sha512-P2pnEp4n75O+QHjyO7cbw/vsw5l93K/8EWyjNCAAybYwUmj3M+hjSQZ9P5TVdUgEG08ueMAP5R4FkuSkElZ5tQ==
+"@smithy/eventstream-serde-config-resolver@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.2.tgz#4d41c1ecad1a9b1c694f32865a2f0d4b5bc0162d"
+  integrity sha512-JGtambizrWP50xHgbzZI04IWU7LdI0nh/wGbqH3sJesYToMi2j/DcoElqyOcqEIG/D4tNyxgRuaqBXWE3zOFhQ==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/eventstream-serde-node@^3.0.4":
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.13.tgz#5aebd7b553becee277e411a2b69f6af8c9d7b3a6"
-  integrity sha512-zqy/9iwbj8Wysmvi7Lq7XFLeDgjRpTbCfwBhJa8WbrylTAHiAu6oQTwdY7iu2lxigbc9YYr9vPv5SzYny5tCXQ==
+"@smithy/eventstream-serde-node@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.4.tgz#0fbd0ac288f02bf485eb307a14254ea8d8767746"
+  integrity sha512-RD6UwNZ5zISpOWPuhVgRz60GkSIp0dy1fuZmj4RYmqLVRtejFqQ16WmfYDdoSoAjlp1LX+FnZo+/hkdmyyGZ1w==
   dependencies:
-    "@smithy/eventstream-serde-universal" "^3.0.13"
-    "@smithy/types" "^3.7.2"
+    "@smithy/eventstream-serde-universal" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/eventstream-serde-universal@^3.0.13":
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.13.tgz#609c922ea14a0a3eed23a28ac110344c935704eb"
-  integrity sha512-L1Ib66+gg9uTnqp/18Gz4MDpJPKRE44geOjOQ2SVc0eiaO5l255ADziATZgjQjqumC7yPtp1XnjHlF1srcwjKw==
+"@smithy/eventstream-serde-universal@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.4.tgz#48b2b416dc0f576917c36373efaa4012f7310ab0"
+  integrity sha512-UeJpOmLGhq1SLox79QWw/0n2PFX+oPRE1ZyRMxPIaFEfCqWaqpB7BU9C8kpPOGEhLF7AwEqfFbtwNxGy4ReENA==
   dependencies:
-    "@smithy/eventstream-codec" "^3.1.10"
-    "@smithy/types" "^3.7.2"
+    "@smithy/eventstream-codec" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/fetch-http-handler@^3.2.4":
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz#8d5199c162a37caa37a8b6848eefa9ca58221a0b"
-  integrity sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==
+"@smithy/fetch-http-handler@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz#c68601b4676787e049b5d464d5f4b825dbb44013"
+  integrity sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==
   dependencies:
-    "@smithy/protocol-http" "^4.1.4"
-    "@smithy/querystring-builder" "^3.0.7"
-    "@smithy/types" "^3.5.0"
-    "@smithy/util-base64" "^3.0.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/querystring-builder" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/fetch-http-handler@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz#fc590dea2470d32559ae298306f1277729d24aa9"
-  integrity sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==
+"@smithy/hash-node@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-4.0.4.tgz#f867cfe6b702ed8893aacd3e097f8ca8ecba579e"
+  integrity sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==
   dependencies:
-    "@smithy/protocol-http" "^4.1.8"
-    "@smithy/querystring-builder" "^3.0.11"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-base64" "^3.0.0"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-buffer-from" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/hash-node@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-3.0.11.tgz#99e09ead3fc99c8cd7ca0f254ea0e35714f2a0d3"
-  integrity sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==
+"@smithy/invalid-dependency@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz#8c2c539b2f22e857b4652bd2427a3d7a8befd610"
+  integrity sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==
   dependencies:
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-buffer-from" "^3.0.0"
-    "@smithy/util-utf8" "^3.0.0"
-    tslib "^2.6.2"
-
-"@smithy/invalid-dependency@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz#8144d7b0af9d34ab5f672e1f674f97f8740bb9ae"
-  integrity sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==
-  dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
 "@smithy/is-array-buffer@^2.2.0":
@@ -3240,168 +3251,162 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/is-array-buffer@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz#9a95c2d46b8768946a9eec7f935feaddcffa5e7a"
-  integrity sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==
+"@smithy/is-array-buffer@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz#55a939029321fec462bcc574890075cd63e94206"
+  integrity sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/middleware-content-length@^3.0.5":
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz#6e08fe52739ac8fb3996088e0f8837e4b2ea187f"
-  integrity sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==
+"@smithy/middleware-content-length@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz#fad1f125779daf8d5f261dae6dbebba0f60c234b"
+  integrity sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==
   dependencies:
-    "@smithy/protocol-http" "^4.1.8"
-    "@smithy/types" "^3.7.2"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/middleware-endpoint@^3.1.0", "@smithy/middleware-endpoint@^3.2.8":
-  version "3.2.8"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.8.tgz#6ca5de80543ba0f0d40e15dc3f9d0f14d192e06e"
-  integrity sha512-OEJZKVUEhMOqMs3ktrTWp7UvvluMJEvD5XgQwRePSbDg1VvBaL8pX8mwPltFn6wk1GySbcVwwyldL8S+iqnrEQ==
+"@smithy/middleware-endpoint@^4.1.13", "@smithy/middleware-endpoint@^4.1.9":
+  version "4.1.13"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.13.tgz#7d5b5f8f61600270bd8c59aabf311c99b9127aba"
+  integrity sha512-xg3EHV/Q5ZdAO5b0UiIMj3RIOCobuS40pBBODguUDVdko6YK6QIzCVRrHTogVuEKglBWqWenRnZ71iZnLL3ZAQ==
   dependencies:
-    "@smithy/core" "^2.5.7"
-    "@smithy/middleware-serde" "^3.0.11"
-    "@smithy/node-config-provider" "^3.1.12"
-    "@smithy/shared-ini-file-loader" "^3.1.12"
-    "@smithy/types" "^3.7.2"
-    "@smithy/url-parser" "^3.0.11"
-    "@smithy/util-middleware" "^3.0.11"
+    "@smithy/core" "^3.6.0"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-middleware" "^4.0.4"
     tslib "^2.6.2"
 
-"@smithy/middleware-retry@^3.0.13":
-  version "3.0.34"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-3.0.34.tgz#136c89fc22d70819fdefc51b0d24952cf98883f1"
-  integrity sha512-yVRr/AAtPZlUvwEkrq7S3x7Z8/xCd97m2hLDaqdz6ucP2RKHsBjEqaUA2ebNv2SsZoPEi+ZD0dZbOB1u37tGCA==
+"@smithy/middleware-retry@^4.1.10":
+  version "4.1.14"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.14.tgz#53ce619463a1ce4b95025aaafdf51369ef893196"
+  integrity sha512-eoXaLlDGpKvdmvt+YBfRXE7HmIEtFF+DJCbTPwuLunP0YUnrydl+C4tS+vEM0+nyxXrX3PSUFqC+lP1+EHB1Tw==
   dependencies:
-    "@smithy/node-config-provider" "^3.1.12"
-    "@smithy/protocol-http" "^4.1.8"
-    "@smithy/service-error-classification" "^3.0.11"
-    "@smithy/smithy-client" "^3.7.0"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-middleware" "^3.0.11"
-    "@smithy/util-retry" "^3.0.11"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/service-error-classification" "^4.0.6"
+    "@smithy/smithy-client" "^4.4.5"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.6"
     tslib "^2.6.2"
     uuid "^9.0.1"
 
-"@smithy/middleware-serde@^3.0.11", "@smithy/middleware-serde@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz#c7d54e0add4f83e05c6878a011fc664e21022f12"
-  integrity sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==
+"@smithy/middleware-serde@^4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz#3704c8cc46acd0a7f910a78ee1d2f23ce928701f"
+  integrity sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/middleware-stack@^3.0.11", "@smithy/middleware-stack@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz#453af2096924e4064d9da4e053cfdf65d9a36acc"
-  integrity sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==
+"@smithy/middleware-stack@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz#58e0c6a0d7678c6ad4d6af8dd9a00f749ffac7c5"
+  integrity sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/node-config-provider@^3.1.12", "@smithy/node-config-provider@^3.1.4":
-  version "3.1.12"
-  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz#1b1d674fc83f943dc7b3017e37f16f374e878a6c"
-  integrity sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==
+"@smithy/node-config-provider@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz#6626fe26c6fe7b0df34f71cb72764ccba414a815"
+  integrity sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==
   dependencies:
-    "@smithy/property-provider" "^3.1.11"
-    "@smithy/shared-ini-file-loader" "^3.1.12"
-    "@smithy/types" "^3.7.2"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/node-http-handler@^3.1.4", "@smithy/node-http-handler@^3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz#94dbb3f15342b656ceba2b26e14aa741cace8919"
-  integrity sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==
+"@smithy/node-http-handler@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz#a022da499ba3af4b6b4c815104fde973c0eccc40"
+  integrity sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==
   dependencies:
-    "@smithy/abort-controller" "^3.1.9"
-    "@smithy/protocol-http" "^4.1.8"
-    "@smithy/querystring-builder" "^3.0.11"
-    "@smithy/types" "^3.7.2"
+    "@smithy/abort-controller" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/querystring-builder" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/property-provider@^3.1.11", "@smithy/property-provider@^3.1.3":
-  version "3.1.11"
-  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-3.1.11.tgz#161cf1c2a2ada361e417382c57f5ba6fbca8acad"
-  integrity sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==
+"@smithy/property-provider@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-4.0.4.tgz#303a8fd99665fff61eeb6ec3922eee53838962c5"
+  integrity sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/protocol-http@^4.1.0", "@smithy/protocol-http@^4.1.4", "@smithy/protocol-http@^4.1.8":
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-4.1.8.tgz#0461758671335f65e8ff3fc0885ab7ed253819c9"
-  integrity sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==
+"@smithy/protocol-http@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.1.2.tgz#8094860c2407f250b80c95899e0385112d6eb98b"
+  integrity sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/querystring-builder@^3.0.11", "@smithy/querystring-builder@^3.0.7":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz#2ed04adbe725671824c5613d0d6f9376d791a909"
-  integrity sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==
+"@smithy/querystring-builder@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz#f7546efd59d457b3d2525a330c6137e5f907864c"
+  integrity sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==
   dependencies:
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-uri-escape" "^3.0.0"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-uri-escape" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/querystring-parser@^3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz#9d3177ea19ce8462f18d9712b395239e1ca1f969"
-  integrity sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==
+"@smithy/querystring-parser@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz#307ab95ee5f1a142ab46c2eddebeae68cb2f703d"
+  integrity sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/service-error-classification@^3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz#d3d7fc0aacd2e60d022507367e55c7939e5bcb8a"
-  integrity sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==
+"@smithy/service-error-classification@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz#5d4d3017f5b62258fbfc1067e14198e125a8286c"
+  integrity sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
 
-"@smithy/shared-ini-file-loader@^3.1.12", "@smithy/shared-ini-file-loader@^3.1.4":
-  version "3.1.12"
-  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz#d98b1b663eb18935ce2cbc79024631d34f54042a"
-  integrity sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==
+"@smithy/shared-ini-file-loader@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz#33c63468b95cfd5e7d642c8131d7acc034025e00"
+  integrity sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/signature-v4@^4.1.0":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-4.2.4.tgz#3501d3d09fd82768867bfc00a7be4bad62f62f4d"
-  integrity sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==
+"@smithy/signature-v4@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.1.2.tgz#5afd9d428bd26bb660bee8075b6e89fe93600c22"
+  integrity sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==
   dependencies:
-    "@smithy/is-array-buffer" "^3.0.0"
-    "@smithy/protocol-http" "^4.1.8"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-hex-encoding" "^3.0.0"
-    "@smithy/util-middleware" "^3.0.11"
-    "@smithy/util-uri-escape" "^3.0.0"
-    "@smithy/util-utf8" "^3.0.0"
+    "@smithy/is-array-buffer" "^4.0.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-hex-encoding" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-uri-escape" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/smithy-client@^3.1.11", "@smithy/smithy-client@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-3.7.0.tgz#8cfaa7b68b7af15e588b96aa14e5dce393f85839"
-  integrity sha512-9wYrjAZFlqWhgVo3C4y/9kpc68jgiSsKUnsFPzr/MSiRL93+QRDafGTfhhKAb2wsr69Ru87WTiqSfQusSmWipA==
+"@smithy/smithy-client@^4.4.1", "@smithy/smithy-client@^4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.4.5.tgz#1c736618f3c4910880cc6862a5826348c1b70d5d"
+  integrity sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==
   dependencies:
-    "@smithy/core" "^2.5.7"
-    "@smithy/middleware-endpoint" "^3.2.8"
-    "@smithy/middleware-stack" "^3.0.11"
-    "@smithy/protocol-http" "^4.1.8"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-stream" "^3.3.4"
-    tslib "^2.6.2"
-
-"@smithy/types@^3.3.0", "@smithy/types@^3.5.0", "@smithy/types@^3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-3.7.2.tgz#05cb14840ada6f966de1bf9a9c7dd86027343e10"
-  integrity sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==
-  dependencies:
+    "@smithy/core" "^3.6.0"
+    "@smithy/middleware-endpoint" "^4.1.13"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-stream" "^4.2.2"
     tslib "^2.6.2"
 
 "@smithy/types@^4.2.0":
@@ -3411,35 +3416,42 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/url-parser@^3.0.11", "@smithy/url-parser@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-3.0.11.tgz#e5f5ffabfb6230159167cf4cc970705fca6b8b2d"
-  integrity sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==
-  dependencies:
-    "@smithy/querystring-parser" "^3.0.11"
-    "@smithy/types" "^3.7.2"
-    tslib "^2.6.2"
-
-"@smithy/util-base64@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-3.0.0.tgz#f7a9a82adf34e27a72d0719395713edf0e493017"
-  integrity sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==
-  dependencies:
-    "@smithy/util-buffer-from" "^3.0.0"
-    "@smithy/util-utf8" "^3.0.0"
-    tslib "^2.6.2"
-
-"@smithy/util-body-length-browser@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz#86ec2f6256310b4845a2f064e2f571c1ca164ded"
-  integrity sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==
+"@smithy/types@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.3.1.tgz#c11276ea16235d798f47a68aef9f44d3dbb70dd4"
+  integrity sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/util-body-length-node@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz#99a291bae40d8932166907fe981d6a1f54298a6d"
-  integrity sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==
+"@smithy/url-parser@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-4.0.4.tgz#049143f4c156356e177bd69242675db26fe4f4db"
+  integrity sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==
+  dependencies:
+    "@smithy/querystring-parser" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@smithy/util-base64@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-4.0.0.tgz#8345f1b837e5f636e5f8470c4d1706ae0c6d0358"
+  integrity sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-browser@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz#965d19109a4b1e5fe7a43f813522cce718036ded"
+  integrity sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-node@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz#3db245f6844a9b1e218e30c93305bfe2ffa473b3"
+  integrity sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==
   dependencies:
     tslib "^2.6.2"
 
@@ -3451,96 +3463,96 @@
     "@smithy/is-array-buffer" "^2.2.0"
     tslib "^2.6.2"
 
-"@smithy/util-buffer-from@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz#559fc1c86138a89b2edaefc1e6677780c24594e3"
-  integrity sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==
+"@smithy/util-buffer-from@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz#b23b7deb4f3923e84ef50c8b2c5863d0dbf6c0b9"
+  integrity sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==
   dependencies:
-    "@smithy/is-array-buffer" "^3.0.0"
+    "@smithy/is-array-buffer" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/util-config-provider@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz#62c6b73b22a430e84888a8f8da4b6029dd5b8efe"
-  integrity sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==
+"@smithy/util-config-provider@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz#e0c7c8124c7fba0b696f78f0bd0ccb060997d45e"
+  integrity sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/util-defaults-mode-browser@^3.0.13":
-  version "3.0.34"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.34.tgz#885312529599cf24b09335cb20439c838e452f9f"
-  integrity sha512-FumjjF631lR521cX+svMLBj3SwSDh9VdtyynTYDAiBDEf8YPP5xORNXKQ9j0105o5+ARAGnOOP/RqSl40uXddA==
+"@smithy/util-defaults-mode-browser@^4.0.17":
+  version "4.0.21"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.21.tgz#47895e42d64060d2a7f803a443fd160d0a329d83"
+  integrity sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==
   dependencies:
-    "@smithy/property-provider" "^3.1.11"
-    "@smithy/smithy-client" "^3.7.0"
-    "@smithy/types" "^3.7.2"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/smithy-client" "^4.4.5"
+    "@smithy/types" "^4.3.1"
     bowser "^2.11.0"
     tslib "^2.6.2"
 
-"@smithy/util-defaults-mode-node@^3.0.13":
-  version "3.0.34"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.34.tgz#5eb0d97231a34e137980abfb08ea5e3a8f2156f7"
-  integrity sha512-vN6aHfzW9dVVzkI0wcZoUXvfjkl4CSbM9nE//08lmUMyf00S75uuCpTrqF9uD4bD9eldIXlt53colrlwKAT8Gw==
+"@smithy/util-defaults-mode-node@^4.0.17":
+  version "4.0.21"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.21.tgz#4682143fbfb0a4c6e08a6151f13af97018e6950e"
+  integrity sha512-/F34zkoU0GzpUgLJydHY8Rxu9lBn8xQC/s/0M0U9lLBkYbA1htaAFjWYJzpzsbXPuri5D1H8gjp2jBum05qBrA==
   dependencies:
-    "@smithy/config-resolver" "^3.0.13"
-    "@smithy/credential-provider-imds" "^3.2.8"
-    "@smithy/node-config-provider" "^3.1.12"
-    "@smithy/property-provider" "^3.1.11"
-    "@smithy/smithy-client" "^3.7.0"
-    "@smithy/types" "^3.7.2"
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/credential-provider-imds" "^4.0.6"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/smithy-client" "^4.4.5"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/util-endpoints@^2.0.5":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz#a088ebfab946a7219dd4763bfced82709894b82d"
-  integrity sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==
+"@smithy/util-endpoints@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz#a24b0801a1b94c0de26ad83da206b9add68117f2"
+  integrity sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==
   dependencies:
-    "@smithy/node-config-provider" "^3.1.12"
-    "@smithy/types" "^3.7.2"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/util-hex-encoding@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz#32938b33d5bf2a15796cd3f178a55b4155c535e6"
-  integrity sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==
+"@smithy/util-hex-encoding@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz#dd449a6452cffb37c5b1807ec2525bb4be551e8d"
+  integrity sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/util-middleware@^3.0.11", "@smithy/util-middleware@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-3.0.11.tgz#2ab5c17266b42c225e62befcffb048afa682b5bf"
-  integrity sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==
+"@smithy/util-middleware@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-4.0.4.tgz#8f639de049082c687841ea5e69c6c36e12e31a3c"
+  integrity sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==
   dependencies:
-    "@smithy/types" "^3.7.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/util-retry@^3.0.11", "@smithy/util-retry@^3.0.3":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-3.0.11.tgz#d267e5ccb290165cee69732547fea17b695a7425"
-  integrity sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==
+"@smithy/util-retry@^4.0.5", "@smithy/util-retry@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.0.6.tgz#f931fdd1f01786b21a82711e185c58410e8e41c7"
+  integrity sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==
   dependencies:
-    "@smithy/service-error-classification" "^3.0.11"
-    "@smithy/types" "^3.7.2"
+    "@smithy/service-error-classification" "^4.0.6"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/util-stream@^3.1.3", "@smithy/util-stream@^3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-3.3.4.tgz#c506ac41310ebcceb0c3f0ba20755e4fe0a90b8d"
-  integrity sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==
+"@smithy/util-stream@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.2.2.tgz#beeb1edf690db9b7d7983f46ca4fb66e22253608"
+  integrity sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==
   dependencies:
-    "@smithy/fetch-http-handler" "^4.1.3"
-    "@smithy/node-http-handler" "^3.3.3"
-    "@smithy/types" "^3.7.2"
-    "@smithy/util-base64" "^3.0.0"
-    "@smithy/util-buffer-from" "^3.0.0"
-    "@smithy/util-hex-encoding" "^3.0.0"
-    "@smithy/util-utf8" "^3.0.0"
+    "@smithy/fetch-http-handler" "^5.0.4"
+    "@smithy/node-http-handler" "^4.0.6"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-buffer-from" "^4.0.0"
+    "@smithy/util-hex-encoding" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/util-uri-escape@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz#e43358a78bf45d50bb736770077f0f09195b6f54"
-  integrity sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==
+"@smithy/util-uri-escape@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz#a96c160c76f3552458a44d8081fade519d214737"
+  integrity sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==
   dependencies:
     tslib "^2.6.2"
 
@@ -3552,12 +3564,12 @@
     "@smithy/util-buffer-from" "^2.2.0"
     tslib "^2.6.2"
 
-"@smithy/util-utf8@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-3.0.0.tgz#1a6a823d47cbec1fd6933e5fc87df975286d9d6a"
-  integrity sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==
+"@smithy/util-utf8@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-4.0.0.tgz#09ca2d9965e5849e72e347c130f2a29d5c0c863c"
+  integrity sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==
   dependencies:
-    "@smithy/util-buffer-from" "^3.0.0"
+    "@smithy/util-buffer-from" "^4.0.0"
     tslib "^2.6.2"
 
 "@socket.io/component-emitter@~3.1.0":
@@ -3698,25 +3710,46 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
+"@types/debug@^4.0.0":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
+  integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/estree@1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
+
+"@types/hast@3.0.4", "@types/hast@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
+  integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
+  dependencies:
+    "@types/unist" "*"
 
 "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/luxon@3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.4.2.tgz#e4fc7214a420173cea47739c33cdf10874694db7"
-  integrity sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==
+"@types/luxon@3.6.2":
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.6.2.tgz#be6536931801f437eafcb9c0f6d6781f72308041"
+  integrity sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==
 
-"@types/marked@4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.3.2.tgz#e2e0ad02ebf5626bd215c5bae2aff6aff0ce9eac"
-  integrity sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  dependencies:
+    "@types/unist" "*"
+
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/node@*", "@types/node@>=13.7.0":
   version "22.15.19"
@@ -3775,10 +3808,15 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
-"@types/turndown@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@types/turndown/-/turndown-5.0.5.tgz#614de24fc9ace4d8c0d9483ba81dc8c1976dd26f"
-  integrity sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==
+"@types/unist@*", "@types/unist@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
+
+"@types/uuid@^9.0.1":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
 
 "@types/which@^2.0.1":
   version "2.0.2"
@@ -3880,10 +3918,15 @@
     "@typescript-eslint/types" "8.32.1"
     eslint-visitor-keys "^4.2.0"
 
-"@uploadcare/file-uploader@1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@uploadcare/file-uploader/-/file-uploader-1.12.0.tgz#9ede4390c437676897110378bbb8a98c677a06ac"
-  integrity sha512-yymQlZPJ5Rx8sK8FnsOMoeI9HgzLR9jSnD8nwIRyDeXKyHJkdHZg22jMgy30ibCXBWbWptaG4I1BG77/o27ODg==
+"@ungap/structured-clone@^1.0.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
+  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@uploadcare/file-uploader@1.16.3-alpha.0":
+  version "1.16.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@uploadcare/file-uploader/-/file-uploader-1.16.3-alpha.0.tgz#b1ee77b53bfb122ff37d1f9c25f845575e0deb85"
+  integrity sha512-QTOJ62NmJ8+G1LX72Y7+Z116YRiRs7EfSEdXNSZPQFhlpooDe1Djdw+UmJv7Kz91aXHhz2DS1gandxz7iqWK0Q==
   dependencies:
     "@symbiotejs/symbiote" "^1.11.7"
     "@uploadcare/image-shrink" "^6.14.1"
@@ -3895,15 +3938,7 @@
   resolved "https://registry.yarnpkg.com/@uploadcare/image-shrink/-/image-shrink-6.14.3.tgz#e626fc7a98b1254d939acae0932c6b58aeca20df"
   integrity sha512-GCZOewwaGdU/FXgK8m1Ct6FHF7CH3LUGcBvsUxPrablkV2Dyl99XdMtyomaZgpsyfRDlVUbvkntDXEB3IZo92A==
 
-"@uploadcare/upload-client@6.14.1":
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/@uploadcare/upload-client/-/upload-client-6.14.1.tgz#1fedc2659a471e7ba2c4977435ad55e54a9e026d"
-  integrity sha512-GvXLq6GGyXHjq7tebfv3IqHFpMzuOSuNPOhwCcNPquUbwoAlTEFPLjB2Ir/EZUuCtTWowluLjo4LPDQwvHbqyA==
-  dependencies:
-    form-data "^4.0.0"
-    ws "^8.2.3"
-
-"@uploadcare/upload-client@^6.14.1":
+"@uploadcare/upload-client@6.14.3", "@uploadcare/upload-client@^6.14.1":
   version "6.14.3"
   resolved "https://registry.yarnpkg.com/@uploadcare/upload-client/-/upload-client-6.14.3.tgz#40b2a1093a64bc2ce904566e703a213effac1763"
   integrity sha512-uZDXb2IuFchpNQdHDxDowKgGPd+9UOy0PIykWEPedMbbBYxh7/UUQ+G53E4KhKe7cV7BV4zoFxUrNx+Ij0lyPw==
@@ -4412,6 +4447,11 @@ b4a@^1.6.4:
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.7.tgz#a99587d4ebbfbd5a6e3b21bdb5d5fa385767abe4"
   integrity sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -4636,6 +4676,11 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
+ccount@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
 chai@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
@@ -4667,6 +4712,21 @@ chalk@^5.0.0, chalk@^5.1.2:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.4.1.tgz#1b48bf0963ec158dce2aacf69c093ae2dd2092d8"
   integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
+
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -4724,108 +4784,109 @@ chownr@^3.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
   integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
-ckeditor5-collaboration@45.1.0:
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/ckeditor5-collaboration/-/ckeditor5-collaboration-45.1.0.tgz#c2f972683c1394c43db2a96dfda8d7b1a026930f"
-  integrity sha512-xNgjQmn9E5VkAh+UGU+vD/CjBqIu96gaPMN8NDfCytEIz6PrW1aYv5/X2mpK7uYaXzO9hcQWypL7s8ID8o9/AQ==
+ckeditor5-collaboration@46.0.0-alpha.0:
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/ckeditor5-collaboration/-/ckeditor5-collaboration-46.0.0-alpha.0.tgz#9df10b1997ad3aafa002b91b8c2561573ea72533"
+  integrity sha512-Eih78vd6QMuhGL0NVP6DsiOqj7Vop50WK6oR0IZIKXuJauh56clJfNYGP9gzJPRLUtTl8qpUssAEQQUl8wY+bw==
   dependencies:
-    "@ckeditor/ckeditor5-collaboration-core" "45.1.0"
+    "@ckeditor/ckeditor5-collaboration-core" "46.0.0-alpha.0"
 
-ckeditor5-premium-features@^45.0.0:
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/ckeditor5-premium-features/-/ckeditor5-premium-features-45.1.0.tgz#530556439b8aeeee8a40cbdcfc7efb5235565ce1"
-  integrity sha512-XRqnJhugVBlkzb80WQ1a8vHmjp5rLaxw/jcg7fhQFbkaM02D8VkoZg0lRO6QtenFpxnRQa10FCjJswwlauBSag==
+ckeditor5-premium-features@^46.0.0-alpha.0:
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/ckeditor5-premium-features/-/ckeditor5-premium-features-46.0.0-alpha.0.tgz#434530cbaca7289a254cee6905362571ad260c18"
+  integrity sha512-1bftX37ipPrGJkPIONQvhmFZTqU8x+7Vrv4FUswEsTWAD7TtEAtRmODfUhbzPBf8eo9n1GjaHwXOG6gTozIg1Q==
   dependencies:
-    "@ckeditor/ckeditor5-ai" "45.1.0"
-    "@ckeditor/ckeditor5-case-change" "45.1.0"
-    "@ckeditor/ckeditor5-collaboration-core" "45.1.0"
-    "@ckeditor/ckeditor5-comments" "45.1.0"
-    "@ckeditor/ckeditor5-document-outline" "45.1.0"
-    "@ckeditor/ckeditor5-email" "45.1.0"
-    "@ckeditor/ckeditor5-export-inline-styles" "45.1.0"
-    "@ckeditor/ckeditor5-export-pdf" "45.1.0"
-    "@ckeditor/ckeditor5-export-word" "45.1.0"
-    "@ckeditor/ckeditor5-format-painter" "45.1.0"
-    "@ckeditor/ckeditor5-import-word" "45.1.0"
-    "@ckeditor/ckeditor5-list-multi-level" "45.1.0"
-    "@ckeditor/ckeditor5-merge-fields" "45.1.0"
-    "@ckeditor/ckeditor5-pagination" "45.1.0"
-    "@ckeditor/ckeditor5-paste-from-office-enhanced" "45.1.0"
-    "@ckeditor/ckeditor5-real-time-collaboration" "45.1.0"
-    "@ckeditor/ckeditor5-revision-history" "45.1.0"
-    "@ckeditor/ckeditor5-slash-command" "45.1.0"
-    "@ckeditor/ckeditor5-source-editing-enhanced" "45.1.0"
-    "@ckeditor/ckeditor5-template" "45.1.0"
-    "@ckeditor/ckeditor5-track-changes" "45.1.0"
-    "@ckeditor/ckeditor5-uploadcare" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
+    "@ckeditor/ckeditor5-ai" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-case-change" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-collaboration-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-comments" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-document-outline" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-email" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-export-inline-styles" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-export-pdf" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-export-word" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-format-painter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-import-word" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-line-height" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list-multi-level" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-merge-fields" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-pagination" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-paste-from-office-enhanced" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-real-time-collaboration" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-revision-history" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-slash-command" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-source-editing-enhanced" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-template" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-track-changes" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-uploadcare" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
 
-ckeditor5@45.1.0, ckeditor5@^45.0.0:
-  version "45.1.0"
-  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-45.1.0.tgz#a646a0cc270faa10c9000ebe8b1910db672cc472"
-  integrity sha512-GvywHMp0uv5sEwkEaB/hqtK1UXDmr5njsLJ4k8ajz4Hx0su/hKuMl+67FnCqMhOxf4OhY/7FRQiiazDTufQ0vA==
+ckeditor5@46.0.0-alpha.0, ckeditor5@^46.0.0-alpha.0:
+  version "46.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-46.0.0-alpha.0.tgz#2608038c05e549a5c0f408f301dd6df7d2cce748"
+  integrity sha512-8BNWXDHuqz2l2vRtF/oFnE+NxBsO47yBBGOZkp9uQKwvP1rrSNqQ7fPGA72P8Lx7G+A9fMoti4J9KaNmgQMzvQ==
   dependencies:
-    "@ckeditor/ckeditor5-adapter-ckfinder" "45.1.0"
-    "@ckeditor/ckeditor5-alignment" "45.1.0"
-    "@ckeditor/ckeditor5-autoformat" "45.1.0"
-    "@ckeditor/ckeditor5-autosave" "45.1.0"
-    "@ckeditor/ckeditor5-basic-styles" "45.1.0"
-    "@ckeditor/ckeditor5-block-quote" "45.1.0"
-    "@ckeditor/ckeditor5-bookmark" "45.1.0"
-    "@ckeditor/ckeditor5-ckbox" "45.1.0"
-    "@ckeditor/ckeditor5-ckfinder" "45.1.0"
-    "@ckeditor/ckeditor5-clipboard" "45.1.0"
-    "@ckeditor/ckeditor5-cloud-services" "45.1.0"
-    "@ckeditor/ckeditor5-code-block" "45.1.0"
-    "@ckeditor/ckeditor5-core" "45.1.0"
-    "@ckeditor/ckeditor5-easy-image" "45.1.0"
-    "@ckeditor/ckeditor5-editor-balloon" "45.1.0"
-    "@ckeditor/ckeditor5-editor-classic" "45.1.0"
-    "@ckeditor/ckeditor5-editor-decoupled" "45.1.0"
-    "@ckeditor/ckeditor5-editor-inline" "45.1.0"
-    "@ckeditor/ckeditor5-editor-multi-root" "45.1.0"
-    "@ckeditor/ckeditor5-emoji" "45.1.0"
-    "@ckeditor/ckeditor5-engine" "45.1.0"
-    "@ckeditor/ckeditor5-enter" "45.1.0"
-    "@ckeditor/ckeditor5-essentials" "45.1.0"
-    "@ckeditor/ckeditor5-find-and-replace" "45.1.0"
-    "@ckeditor/ckeditor5-font" "45.1.0"
-    "@ckeditor/ckeditor5-fullscreen" "45.1.0"
-    "@ckeditor/ckeditor5-heading" "45.1.0"
-    "@ckeditor/ckeditor5-highlight" "45.1.0"
-    "@ckeditor/ckeditor5-horizontal-line" "45.1.0"
-    "@ckeditor/ckeditor5-html-embed" "45.1.0"
-    "@ckeditor/ckeditor5-html-support" "45.1.0"
-    "@ckeditor/ckeditor5-icons" "45.1.0"
-    "@ckeditor/ckeditor5-image" "45.1.0"
-    "@ckeditor/ckeditor5-indent" "45.1.0"
-    "@ckeditor/ckeditor5-language" "45.1.0"
-    "@ckeditor/ckeditor5-link" "45.1.0"
-    "@ckeditor/ckeditor5-list" "45.1.0"
-    "@ckeditor/ckeditor5-markdown-gfm" "45.1.0"
-    "@ckeditor/ckeditor5-media-embed" "45.1.0"
-    "@ckeditor/ckeditor5-mention" "45.1.0"
-    "@ckeditor/ckeditor5-minimap" "45.1.0"
-    "@ckeditor/ckeditor5-page-break" "45.1.0"
-    "@ckeditor/ckeditor5-paragraph" "45.1.0"
-    "@ckeditor/ckeditor5-paste-from-office" "45.1.0"
-    "@ckeditor/ckeditor5-remove-format" "45.1.0"
-    "@ckeditor/ckeditor5-restricted-editing" "45.1.0"
-    "@ckeditor/ckeditor5-select-all" "45.1.0"
-    "@ckeditor/ckeditor5-show-blocks" "45.1.0"
-    "@ckeditor/ckeditor5-source-editing" "45.1.0"
-    "@ckeditor/ckeditor5-special-characters" "45.1.0"
-    "@ckeditor/ckeditor5-style" "45.1.0"
-    "@ckeditor/ckeditor5-table" "45.1.0"
-    "@ckeditor/ckeditor5-theme-lark" "45.1.0"
-    "@ckeditor/ckeditor5-typing" "45.1.0"
-    "@ckeditor/ckeditor5-ui" "45.1.0"
-    "@ckeditor/ckeditor5-undo" "45.1.0"
-    "@ckeditor/ckeditor5-upload" "45.1.0"
-    "@ckeditor/ckeditor5-utils" "45.1.0"
-    "@ckeditor/ckeditor5-watchdog" "45.1.0"
-    "@ckeditor/ckeditor5-widget" "45.1.0"
-    "@ckeditor/ckeditor5-word-count" "45.1.0"
+    "@ckeditor/ckeditor5-adapter-ckfinder" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-alignment" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-autoformat" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-autosave" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-basic-styles" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-block-quote" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-bookmark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ckbox" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ckfinder" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-clipboard" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-cloud-services" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-code-block" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-core" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-easy-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-balloon" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-classic" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-decoupled" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-inline" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-emoji" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-engine" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-enter" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-essentials" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-find-and-replace" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-font" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-fullscreen" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-heading" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-highlight" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-horizontal-line" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-html-embed" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-html-support" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-icons" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-image" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-indent" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-language" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-link" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-list" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-markdown-gfm" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-media-embed" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-mention" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-minimap" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-page-break" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-paragraph" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-paste-from-office" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-remove-format" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-restricted-editing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-select-all" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-show-blocks" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-source-editing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-special-characters" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-style" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-table" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-theme-lark" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-typing" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-ui" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-undo" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-upload" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-utils" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-watchdog" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-widget" "46.0.0-alpha.0"
+    "@ckeditor/ckeditor5-word-count" "46.0.0-alpha.0"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -4896,24 +4957,36 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-color-convert@2.0.1, color-convert@^2.0.1:
+color-convert@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-3.1.0.tgz#ce16ebb832f9d7522649ed9e11bc0ccb9433a524"
+  integrity sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==
+  dependencies:
+    color-name "^2.0.0"
+
+color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-2.0.0.tgz#03ff6b1b5aec9bb3cf1ed82400c2790dfcd01d2d"
+  integrity sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==
+
+color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-parse@1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/color-parse/-/color-parse-1.4.2.tgz#78651f5d34df1a57f997643d86f7f87268ad4eb5"
-  integrity sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==
+color-parse@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/color-parse/-/color-parse-2.0.2.tgz#37b46930424924060988edf25b24e6ffb4a1dc3f"
+  integrity sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==
   dependencies:
-    color-name "^1.0.0"
+    color-name "^2.0.0"
 
 colord@^2.9.3:
   version "2.9.3"
@@ -4931,6 +5004,11 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -5284,7 +5362,7 @@ date-fns@^4.0.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.3.7, debug@^4.4.1:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.3.7, debug@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -5307,6 +5385,13 @@ decamelize@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-6.0.0.tgz#8cad4d916fde5c41a264a43d0ecc56fe3d31749e"
   integrity sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==
+
+decode-named-character-reference@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz#25c32ae6dd5e21889549d40f676030e9514cc0ed"
+  integrity sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==
+  dependencies:
+    character-entities "^2.0.0"
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -5360,10 +5445,17 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-dequal@^2.0.3:
+dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+devlop@^1.0.0, devlop@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
 
 diff@^7.0.0:
   version "7.0.0"
@@ -5687,10 +5779,10 @@ es-to-primitive@^1.3.0:
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
 
-es-toolkit@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.32.0.tgz#a3254bffe31fcd52a0abb1b77074e5f0fa76b7fd"
-  integrity sha512-ZfSfHP1l6ubgW/B/FRtqb9bYdMvI6jizbOSfbwwJNcOQ1QE6TFsC3jpQkZ900uUPSR3t3SU5Ds7UWKnYz+uP8Q==
+es-toolkit@1.39.5:
+  version "1.39.5"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.39.5.tgz#ee2a78a66aafb76c7345af0ea8c06722c78ef1fd"
+  integrity sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==
 
 es-toolkit@^1.35.0:
   version "1.38.0"
@@ -5776,6 +5868,11 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escodegen@^2.1.0:
   version "2.1.0"
@@ -6001,7 +6098,7 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.2.tgz#a8f26adb96bf78e8cd8ad1037928d5e5c0679d91"
   integrity sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -6540,6 +6637,147 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-embedded@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz#be4477780fbbe079cdba22982e357a0de4ba853e"
+  integrity sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-is-element "^3.0.0"
+
+hast-util-from-dom@5.0.1, hast-util-from-dom@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz#c3c92fbd8d4e1c1625edeb3a773952b9e4ad64a8"
+  integrity sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hastscript "^9.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-has-property@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz#4e595e3cddb8ce530ea92f6fc4111a818d8e7f93"
+  integrity sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-is-body-ok-link@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz#ef63cb2f14f04ecf775139cd92bda5026380d8b4"
+  integrity sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-is-element@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz#6e31a6532c217e5b533848c7e52c9d9369ca0932"
+  integrity sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-minify-whitespace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz#7588fd1a53f48f1d30406b81959dffc3650daf55"
+  integrity sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-embedded "^3.0.0"
+    hast-util-is-element "^3.0.0"
+    hast-util-whitespace "^3.0.0"
+    unist-util-is "^6.0.0"
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-phrasing@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz#fa284c0cd4a82a0dd6020de8300a7b1ebffa1690"
+  integrity sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-embedded "^3.0.0"
+    hast-util-has-property "^3.0.0"
+    hast-util-is-body-ok-link "^3.0.0"
+    hast-util-is-element "^3.0.0"
+
+hast-util-to-dom@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-dom/-/hast-util-to-dom-4.0.1.tgz#d57a84b9d320c2ce3dd867cefd7dff34b83c2176"
+  integrity sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    property-information "^7.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-to-html@9.0.5, hast-util-to-html@^9.0.0:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
+
+hast-util-to-mdast@10.1.2, hast-util-to-mdast@^10.0.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz#bc76f7f5f72f2cde4d6a66ad4cd0aba82bb79909"
+  integrity sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-phrasing "^3.0.0"
+    hast-util-to-html "^9.0.0"
+    hast-util-to-text "^4.0.0"
+    hast-util-whitespace "^3.0.0"
+    mdast-util-phrasing "^4.0.0"
+    mdast-util-to-hast "^13.0.0"
+    mdast-util-to-string "^4.0.0"
+    rehype-minify-whitespace "^6.0.0"
+    trim-trailing-lines "^2.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+
+hast-util-to-text@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz#57b676931e71bf9cb852453678495b3080bfae3e"
+  integrity sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    hast-util-is-element "^3.0.0"
+    unist-util-find-after "^5.0.0"
+
+hast-util-whitespace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
+  integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hastscript@9.0.1, hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -6561,6 +6799,11 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 htmlfy@^0.6.0:
   version "0.6.7"
@@ -6882,7 +7125,7 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
-is-plain-obj@^4.1.0:
+is-plain-obj@^4.0.0, is-plain-obj@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
@@ -7416,6 +7659,11 @@ long@^5.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
+longest-streak@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
+  integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -7450,10 +7698,10 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
-luxon@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.5.0.tgz#6b6f65c5cd1d61d1fd19dbf07ee87a50bf4b8e20"
-  integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
+luxon@3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.6.1.tgz#d283ffc4c0076cb0db7885ec6da1c49ba97e47b0"
+  integrity sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==
 
 lz-string@^1.5.0:
   version "1.5.0"
@@ -7500,15 +7748,161 @@ make-fetch-happen@^14.0.0, make-fetch-happen@^14.0.1, make-fetch-happen@^14.0.2,
     promise-retry "^2.0.1"
     ssri "^12.0.0"
 
-marked@4.0.12:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
-  integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
+markdown-table@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.4.tgz#fe44d6d410ff9d6f2ea1797a3f60aa4d2b631c2a"
+  integrity sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+mdast-util-find-and-replace@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz#70a3174c894e14df722abf43bc250cbae44b11df"
+  integrity sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    escape-string-regexp "^5.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
+mdast-util-from-markdown@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz#4850390ca7cf17413a9b9a0fbefcd1bc0eb4160a"
+  integrity sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark "^4.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+mdast-util-gfm-autolink-literal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz#abd557630337bd30a6d5a4bd8252e1c2dc0875d5"
+  integrity sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    ccount "^2.0.0"
+    devlop "^1.0.0"
+    mdast-util-find-and-replace "^3.0.0"
+    micromark-util-character "^2.0.0"
+
+mdast-util-gfm-footnote@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz#7778e9d9ca3df7238cc2bd3fa2b1bf6a65b19403"
+  integrity sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.1.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+
+mdast-util-gfm-strikethrough@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz#d44ef9e8ed283ac8c1165ab0d0dfd058c2764c16"
+  integrity sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz#7a435fb6223a72b0862b33afbd712b6dae878d38"
+  integrity sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    markdown-table "^3.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm-task-list-item@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz#e68095d2f8a4303ef24094ab642e1047b991a936"
+  integrity sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz#2cdf63b92c2a331406b0fb0db4c077c1b0331751"
+  integrity sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==
+  dependencies:
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-gfm-autolink-literal "^2.0.0"
+    mdast-util-gfm-footnote "^2.0.0"
+    mdast-util-gfm-strikethrough "^2.0.0"
+    mdast-util-gfm-table "^2.0.0"
+    mdast-util-gfm-task-list-item "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-newline-to-break@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz#4e73ef621b6b1a590240336cfe6c29915e198df0"
+  integrity sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-find-and-replace "^3.0.0"
+
+mdast-util-phrasing@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz#7cc0a8dec30eaf04b7b1a9661a92adb3382aa6e3"
+  integrity sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    unist-util-is "^6.0.0"
+
+mdast-util-to-hast@^13.0.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz#5ca58e5b921cc0a3ded1bc02eed79a4fe4fe41f4"
+  integrity sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    trim-lines "^3.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
+mdast-util-to-markdown@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz#f910ffe60897f04bb4b7e7ee434486f76288361b"
+  integrity sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-phrasing "^4.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    unist-util-visit "^5.0.0"
+    zwitch "^2.0.0"
+
+mdast-util-to-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
+  integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
 
 mdn-data@2.0.28:
   version "2.0.28"
@@ -7534,6 +7928,279 @@ merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromark-core-commonmark@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz#c691630e485021a68cf28dbc2b2ca27ebf678cd4"
+  integrity sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-destination "^2.0.0"
+    micromark-factory-label "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-factory-title "^2.0.0"
+    micromark-factory-whitespace "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-html-tag-name "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-autolink-literal@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz#6286aee9686c4462c1e3552a9d505feddceeb935"
+  integrity sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-footnote@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz#4dab56d4e398b9853f6fe4efac4fc9361f3e0750"
+  integrity sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-strikethrough@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz#86106df8b3a692b5f6a92280d3879be6be46d923"
+  integrity sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-table@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz#fac70bcbf51fe65f5f44033118d39be8a9b5940b"
+  integrity sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-tagfilter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz#f26d8a7807b5985fba13cf61465b58ca5ff7dc57"
+  integrity sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-task-list-item@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz#bcc34d805639829990ec175c3eea12bb5b781f2c"
+  integrity sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz#3e13376ab95dd7a5cfd0e29560dfe999657b3c5b"
+  integrity sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==
+  dependencies:
+    micromark-extension-gfm-autolink-literal "^2.0.0"
+    micromark-extension-gfm-footnote "^2.0.0"
+    micromark-extension-gfm-strikethrough "^2.0.0"
+    micromark-extension-gfm-table "^2.0.0"
+    micromark-extension-gfm-tagfilter "^2.0.0"
+    micromark-extension-gfm-task-list-item "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-destination@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz#8fef8e0f7081f0474fbdd92deb50c990a0264639"
+  integrity sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-label@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz#5267efa97f1e5254efc7f20b459a38cb21058ba1"
+  integrity sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-space@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz#36d0212e962b2b3121f8525fc7a3c7c029f334fc"
+  integrity sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-title@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz#237e4aa5d58a95863f01032d9ee9b090f1de6e94"
+  integrity sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-whitespace@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz#06b26b2983c4d27bfcc657b33e25134d4868b0b1"
+  integrity sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-character@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-chunked@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz#47fbcd93471a3fccab86cff03847fc3552db1051"
+  integrity sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-classify-character@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz#d399faf9c45ca14c8b4be98b1ea481bced87b629"
+  integrity sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-combine-extensions@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz#2a0f490ab08bff5cc2fd5eec6dd0ca04f89b30a9"
+  integrity sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==
+  dependencies:
+    micromark-util-chunked "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-decode-numeric-character-reference@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz#fcf15b660979388e6f118cdb6bf7d79d73d26fe5"
+  integrity sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-decode-string@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz#6cb99582e5d271e84efca8e61a807994d7161eb2"
+  integrity sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+
+micromark-util-html-tag-name@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz#e40403096481986b41c106627f98f72d4d10b825"
+  integrity sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==
+
+micromark-util-normalize-identifier@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz#c30d77b2e832acf6526f8bf1aa47bc9c9438c16d"
+  integrity sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-resolve-all@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz#e1a2d62cdd237230a2ae11839027b19381e31e8b"
+  integrity sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-subtokenize@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz#d8ade5ba0f3197a1cf6a2999fbbfe6357a1a19ee"
+  integrity sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+
+micromark-util-types@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz#f00225f5f5a0ebc3254f96c36b6605c4b393908e"
+  integrity sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+
+micromark@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-4.0.2.tgz#91395a3e1884a198e62116e33c9c568e39936fdb"
+  integrity sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromatch@^4.0.2, micromatch@^4.0.8:
   version "4.0.8"
@@ -8611,6 +9278,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-information@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.1.0.tgz#b622e8646e02b580205415586b40804d3e8bfd5d"
+  integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
+
 protobufjs@7.5.0:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.0.tgz#a317ad80713e9db43c8e55afa8636a9aa76bb630"
@@ -8873,6 +9545,94 @@ regexp.prototype.flags@^1.5.3:
     get-proto "^1.0.1"
     gopd "^1.2.0"
     set-function-name "^2.0.2"
+
+rehype-dom-parse@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/rehype-dom-parse/-/rehype-dom-parse-5.0.2.tgz#358c82e4733c53b3d31c5c0a9d0a15892f04a9fa"
+  integrity sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-from-dom "^5.0.0"
+    unified "^11.0.0"
+
+rehype-dom-stringify@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/rehype-dom-stringify/-/rehype-dom-stringify-4.0.2.tgz#8dfd1a7aec5202596f665c14c66f4ab33faac11c"
+  integrity sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-to-dom "^4.0.0"
+    unified "^11.0.0"
+
+rehype-minify-whitespace@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz#7dd234ce0775656ce6b6b0aad0a6093de29b2278"
+  integrity sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-minify-whitespace "^1.0.0"
+
+rehype-remark@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-remark/-/rehype-remark-10.0.1.tgz#f669fa68cfb8b5baaf4fa95476a923516111a43b"
+  integrity sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    hast-util-to-mdast "^10.0.0"
+    unified "^11.0.0"
+    vfile "^6.0.0"
+
+remark-breaks@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-4.0.0.tgz#dcc19a2891733906f3b97eaa8acb8621e8da8852"
+  integrity sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-newline-to-break "^2.0.0"
+    unified "^11.0.0"
+
+remark-gfm@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.1.tgz#33227b2a74397670d357bf05c098eaf8513f0d6b"
+  integrity sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-gfm "^3.0.0"
+    micromark-extension-gfm "^3.0.0"
+    remark-parse "^11.0.0"
+    remark-stringify "^11.0.0"
+    unified "^11.0.0"
+
+remark-parse@11.0.0, remark-parse@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-11.0.0.tgz#aa60743fcb37ebf6b069204eb4da304e40db45a1"
+  integrity sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unified "^11.0.0"
+
+remark-rehype@11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-11.1.2.tgz#2addaadda80ca9bd9aa0da763e74d16327683b37"
+  integrity sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    mdast-util-to-hast "^13.0.0"
+    unified "^11.0.0"
+    vfile "^6.0.0"
+
+remark-stringify@11.0.0, remark-stringify@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-11.0.0.tgz#4c5b01dd711c269df1aaae11743eb7e2e7636fd3"
+  integrity sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    unified "^11.0.0"
 
 request@^2.88.2:
   version "2.88.2"
@@ -9428,6 +10188,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+space-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+
 spacetrim@0.11.59:
   version "0.11.59"
   resolved "https://registry.yarnpkg.com/spacetrim/-/spacetrim-0.11.59.tgz#b9cf378b5d1ab9ed729d4c7c3e4412ec00a187b9"
@@ -9626,6 +10391,14 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-entities@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.4.tgz#b3b79ef5f277cc4ac73caeb0236c5ba939b3a4f3"
+  integrity sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+  dependencies:
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
 
 stringify-object@^3.3.0:
   version "3.3.0"
@@ -9907,6 +10680,21 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
+trim-trailing-lines@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz#9aac7e89b09cb35badf663de7133c6de164f86df"
+  integrity sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==
+
+trough@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
+  integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
+
 ts-api-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
@@ -9932,18 +10720,6 @@ tunnel-agent@^0.6.0:
   integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
   dependencies:
     safe-buffer "^5.0.1"
-
-turndown-plugin-gfm@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
-  integrity sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==
-
-turndown@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.0.tgz#67d614fe8371fb511079a93345abfd156c0ffcf4"
-  integrity sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==
-  dependencies:
-    "@mixmark-io/domino" "^2.2.0"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -10076,6 +10852,19 @@ undici@^6.19.5, undici@^6.20.1:
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.3.tgz#185752ad92c3d0efe7a7d1f6854a50f83b552d7a"
   integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
+unified@11.0.5, unified@^11.0.0:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
+  integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    bail "^2.0.0"
+    devlop "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^6.0.0"
+
 unique-filename@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-4.0.0.tgz#a06534d370e7c977a939cd1d11f7f0ab8f1fed13"
@@ -10089,6 +10878,52 @@ unique-slug@^5.0.0:
   integrity sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-find-after@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz#3fccc1b086b56f34c8b798e1ff90b5c54468e896"
+  integrity sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
+unist-util-is@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.0.tgz#b775956486aff107a9ded971d996c173374be424"
+  integrity sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-position@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-5.0.0.tgz#678f20ab5ca1207a97d7ea8a388373c9cf896be4"
+  integrity sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-visit-parents@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz#4d5f85755c3b8f0dc69e21eca5d6d82d22162815"
+  integrity sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
+unist-util-visit@5.0.0, unist-util-visit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.0.0.tgz#a7de1f31f72ffd3519ea71814cccf5fd6a9217d6"
+  integrity sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
 
 universal-user-agent@^7.0.0, universal-user-agent@^7.0.2:
   version "7.0.3"
@@ -10190,6 +11025,22 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vfile-message@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
+  integrity sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+vfile@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile-message "^4.0.0"
+
 vite-node@2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.1.9.tgz#549710f76a643f1c39ef34bdb5493a944e4f895f"
@@ -10251,6 +11102,11 @@ wait-port@^1.1.0:
     chalk "^4.1.2"
     commander "^9.3.0"
     debug "^4.3.4"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 web-streams-polyfill@^3.0.3:
   version "3.3.3"
@@ -10529,3 +11385,8 @@ zip-stream@^6.0.1:
     archiver-utils "^5.0.0"
     compress-commons "^6.0.2"
     readable-stream "^4.0.0"
+
+zwitch@^2.0.0, zwitch@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Update imports to match CKEditor 5 v46. Closes https://github.com/ckeditor/ckeditor5-react/issues/602

BREAKING CHANGE: Switched to new import names introduced in CKEditor 5 v46. Older versions are no longer supported.

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/18583
