### PR TITLE
Accept an internal CKEditor 5 release as a valid peer dependency

### DIFF
--- a/.changelog/20251030134025_internal_4151_upgrade_to_node_24_11.md
+++ b/.changelog/20251030134025_internal_4151_upgrade_to_node_24_11.md
@@ -2,4 +2,4 @@
 type: Other
 ---
 
-Upgrade to Node v24.11.
+Upgrade the development environment to Node v24.11.

--- a/.changelog/20251218115633_i_637.md
+++ b/.changelog/20251218115633_i_637.md
@@ -1,0 +1,7 @@
+---
+type: Other
+closes:
+  - 637
+---
+
+Extend the `ckeditor5` peer dependency range to accept an internal release (`^0.0.0-internal`) in addition to stable and nightly versions.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@ckeditor/ckeditor5-integrations-common": "^2.2.2"
   },
   "peerDependencies": {
-    "ckeditor5": ">=46.0.0 || ^0.0.0-nightly",
+    "ckeditor5": ">=46.0.0 || ^0.0.0-nightly || ^0.0.0-internal",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### 🚀 Summary

Accept an internal CKEditor 5 release as a valid peer dependency.

---

### 📌 Related issues

* Closes #637.

---

### 💡 Additional information

```
$ pnpm run release:prepare-packages --compile-only

> @ckeditor/ckeditor5-react@11.0.0 release:prepare-packages /Users/pomek/Projects/ckeditor/ckeditor5-react
> node ./scripts/preparepackages.js --compile-only

[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
↓ Verifying the repository.
↓ Updating the `#version` field.
✔ Running build command.
✔ Creating the `ckeditor5-react` package in the release directory.
✔ Cleaning-up.
✔ Verify release directory.
↓ Commit & tag.

$ cat release/ckeditor5-react/package.json | grep 0.0.0

    "ckeditor5": ">=46.0.0 || ^0.0.0-nightly || ^0.0.0-internal",
```