### PR TITLE
Fail internal CI when LTS key is missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,7 @@ jobs:
             then
               echo "Skipping duplicated integration run because ${EDITOR_VERSION_TAG} and latest resolve to the same major version."
               circleci-agent step halt
+              exit 0
             fi
       - run:
           name: Verify license key
@@ -194,6 +195,7 @@ jobs:
               then
                 echo "Skipping the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is not available in this community environment."
                 circleci-agent step halt
+                exit 0
               fi
 
               echo "Failing the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is required in this environment."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,8 +190,14 @@ jobs:
 
             if [[ "<< parameters.ckeditorDistTag >>" != "latest" && -z ${CKEDITOR_LICENSE_KEY} ]];
             then
-              echo "Skipping the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is not available in this environment."
-              circleci-agent step halt
+              if [[ -z ${CODECOV_TOKEN} ]];
+              then
+                echo "Skipping the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is not available in this community environment."
+                circleci-agent step halt
+              fi
+
+              echo "Failing the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is required in this environment."
+              exit 1
             fi
       - run:
           name: Install CKEditor packages for << parameters.ckeditorDistTag >>


### PR DESCRIPTION
### 🚀 Summary

Fail LTS integration runs in internal CI when `CKEDITOR_LICENSE_KEY` is missing so a green pipeline means the lane actually ran.
Keep community-style runs skippable by continuing to halt only when secrets are intentionally unavailable.
No changelog entry needed because this is an internal-only CI change.

---

### 📌 Related issues

* See #670

---

### 💡 Additional information

Mirrors the CI behavior already applied in `ckeditor5-angular` for the same missing-license-key case.