### PR TITLE
Pin pnpm to 11.14.0 in CI to fix LTS integration failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,10 @@ commands:
           command: sudo corepack disable
       - run:
           name: Install pnpm
-          command: sudo npm i -g pnpm@^11
+          # Pinned to 11.14.0. pnpm 11.15.x regressed optional-peer resolution, which forks
+          # the CKEditor dependency graph (`debug`'s optional `supports-color` peer) into two
+          # copies and breaks the LTS integration tests with `plugincollection-plugin-name-conflict`.
+          command: sudo npm i -g pnpm@11.14.0
       - run:
           name: Install dependencies
           command: pnpm install


### PR DESCRIPTION
## Problem

The nightly `tests_integration` matrix job for the **`lts-v47`** editor tag started failing (first red nightly on 2026-07-20). Every editor failed to mount with:

```
CKEditorError: plugincollection-plugin-name-conflict {"pluginName":"Paragraph"}
```

…producing 50+ failures across `useMultiRootEditor`, `ckeditor-classiceditor`, and the `issues/*` context tests (plus a watchdog `Cannot read properties of null (reading 'model')` crash).

## Root cause

Not CKBox, not the lockfile, not the CKEditor 47.7.3 release itself — it's a **pnpm regression**.

CI bootstrap installs pnpm via floating `sudo npm i -g pnpm@^11`, which grabs the **latest** 11.x. **pnpm 11.15.1 was published 2026-07-19 22:30 UTC — ~4 hours before the failing nightly.** pnpm 11.15.x changed optional-peer resolution so that `debug`'s optional `supports-color` peer forks the entire CKEditor dependency graph into two peer-resolution copies:

```
@ckeditor/ckeditor5-paragraph@47.7.3                       (plain)
@ckeditor/ckeditor5-paragraph@47.7.3_supports-color@8.1.1  (forked copy)
```

Two physical copies of the same version load two `Paragraph` classes with the same `pluginName` → `plugincollection-plugin-name-conflict` → the editor never initializes.

### Deterministic bisect (same repo, lockfile and CKEditor 47.7.3; only pnpm differs)

| pnpm | doppelganger? |
|------|---------------|
| 11.9.0  | ✅ clean |
| 11.14.0 | ✅ clean |
| 11.15.1 | ❌ forked graph → failure |

## Fix

Pin CI to the last known-good pnpm (`11.14.0`) instead of floating `^11`. Validated green on CircleCI (LTS integration job passes).

## Follow-ups (not in this PR)

- `engines.pnpm` is `^11.9.0`, which still *permits* the broken 11.15.x — worth tightening.
- The floating-`pnpm@^11` pattern likely affects other ckeditor5 repos/CI tooling.
- Worth filing a pnpm upstream regression report for the `supports-color` optional-peer doppelganger in 11.15.x.
