### PR TITLE
Migrate npm publishing to OIDC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,24 @@ commands:
       - add_ssh_keys:
           fingerprints:
             - "a0:41:a2:56:c8:7d:3f:29:41:d1:87:92:fd:50:2b:6b"
+      - run:
+          name: Add GitHub to known hosts
+          command: >-
+            printf '%s\n' 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl'
+            >> ~/.ssh/known_hosts
 
-  npm_login_command:
-    description: "Enable interacting with `npm` using an auth token"
+  npm_oidc_command:
+    description: "Enable publishing to `npm` using OIDC"
     steps:
       - run:
-          name: Login to the npm registry using '.npmrc' file
-          command: echo "//registry.npmjs.org/:_authToken=\${CKE5_NPM_TOKEN}" > ~/.npmrc
+          name: Install npm with CircleCI OIDC support
+          command: sudo npm i -g npm@^11.11.0
+      - run:
+          name: Get npm OIDC token
+          command: |
+            NPM_ID_TOKEN=$(circleci run oidc get \
+              --claims '{"aud":"npm:registry.npmjs.org"}')
+            printf 'export NPM_ID_TOKEN=%q\n' "$NPM_ID_TOKEN" >> "$BASH_ENV"
 
   gpg_credentials_command:
     description: "Setup GPG configuration"
@@ -69,6 +80,7 @@ commands:
             git config --global user.signingkey 3F615B600F38B27B
             git config --global commit.gpgsign true
             git config --global tag.gpgSign true
+            git remote set-url origin git@github.com:ckeditor/ckeditor5-react.git
 
 jobs:
   validate:
@@ -217,7 +229,11 @@ jobs:
             fi
       - run:
           name: Trigger the release pipeline
-          command: pnpm ckeditor5-dev-ci-trigger-circle-build --slug ckeditor/ckeditor5-react --release-branch master
+          command: >-
+            pnpm ckeditor5-dev-ci-trigger-circle-build
+            --slug ckeditor/ckeditor5-react
+            --release-branch master
+            --pipeline-definition-id 686138b9-93ef-4c1f-8889-5b7fb8981e51
 
   release_project:
     docker:
@@ -237,7 +253,7 @@ jobs:
               echo "There is a newer commit in the repository on the \`#master\` branch. Use its build to start the release."
               circleci-agent step halt
             fi
-      - npm_login_command
+      - npm_oidc_command
       - git_credentials_command
       - run:
           name: Verify if a releaser triggered the job

--- a/scripts-tests/publishpackages.mjs
+++ b/scripts-tests/publishpackages.mjs
@@ -1,0 +1,49 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Listr } from 'listr2';
+import * as releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
+
+vi.mock( '@ckeditor/ckeditor5-dev-release-tools' );
+vi.mock( 'listr2', () => ( {
+	Listr: vi.fn( function FakeListr() {
+		this.run = vi.fn().mockReturnValue( Promise.resolve( undefined ) );
+	} )
+} ) );
+
+describe( 'scripts/publishpackages', () => {
+	let listrTasks;
+
+	beforeEach( async () => {
+		vi.resetModules();
+		vi.stubEnv( 'CKE5_RELEASE_TOKEN', 'github-token' );
+
+		vi.mocked( releaseTools.getLastFromChangelog ).mockReturnValue( '1.0.0' );
+		vi.mocked( releaseTools.getChangesForVersion ).mockReturnValue( 'Changes.' );
+		vi.mocked( releaseTools.getNpmTagFromVersion ).mockReturnValue( 'latest' );
+
+		await import( '../scripts/publishpackages.js' );
+
+		listrTasks = vi.mocked( Listr ).mock.calls[ 0 ][ 0 ];
+	} );
+
+	describe( 'Publishing packages.', () => {
+		it( 'publishes packages using OIDC', async () => {
+			vi.mocked( releaseTools.publishPackages ).mockResolvedValue( undefined );
+
+			const { task } = listrTasks.find( ( { title } ) => title === 'Publishing packages.' );
+
+			await task( {}, {} );
+
+			expect( releaseTools.publishPackages ).toHaveBeenCalledTimes( 1 );
+
+			const [ options ] = vi.mocked( releaseTools.publishPackages ).mock.calls[ 0 ];
+
+			expect( options ).toHaveProperty( 'useOidc', true );
+			expect( options ).not.toHaveProperty( 'npmOwner' );
+		} );
+	} );
+} );

--- a/scripts/publishpackages.js
+++ b/scripts/publishpackages.js
@@ -26,7 +26,7 @@ const tasks = new Listr( [
 		task: async ( _, task ) => {
 			return releaseTools.publishPackages( {
 				packagesDirectory: 'release',
-				npmOwner: 'ckeditor',
+				useOidc: true,
 				npmTag: cliArguments.npmTag,
 				listrTask: task,
 				confirmationCallback: () => {


### PR DESCRIPTION
### 🚀 Summary

Migrates the release workflow from the long-lived `CKE5_NPM_TOKEN` to npm Trusted Publishing with CircleCI OIDC.

The PR also:

* Installs npm `^11.11.0` in the release job because the `cimg/node:24.11.0` image ships an npm version whose OIDC implementation does not recognize CircleCI (support was added in npm/cli#8925, first released in npm 11.11.0).
* Configures `releaseTools.publishPackages()` to use OIDC (`useOidc: true`) and removes the login-based `npmOwner` option, as `npm whoami` does not support OIDC authentication.
* Triggers the trusted GitHub App pipeline definition during releases (`--pipeline-definition-id`).
* Switches the `origin` remote to SSH and pins GitHub's published Ed25519 host key so the release commit and tag can be pushed from the GitHub App checkout without an interactive prompt.
* Adds a focused script test verifying the OIDC option and the absence of `npmOwner`.

The changes mirror the Mrgit and Umberto migrations driven by ckeditor/ckeditor5-internal#4432.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4651.

---

### 💡 Additional information

This is an internal CI change, so no changelog entry is required. ESLint and script tests pass locally, and the trusted publisher configuration inputs (organization, project, and pipeline definition IDs) were verified against the CircleCI API. Before the first release on this flow, a trusted publisher for `@ckeditor/ckeditor5-react` must be configured on npm, and a release after merge is required to validate the OIDC exchange with npm end to end.
